### PR TITLE
fix: deprecated code (set-env)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           WORKFLOW_ID=$(curl "Authorization: token ${{ github.token }}" https://api.github.com/repos/${{ github.repository }}/actions/workflows/linux.yml | jq '.id')
           echo "Workflow id: ${WORKFLOW_ID}"
-          echo "::set-env name=WORKFLOW_ID::${WORKFLOW_ID}"
+          echo "WORKFLOW_ID=${WORKFLOW_ID}" >> $GITHUB_ENV
 
       - uses: styfle/cancel-workflow-action@0.3.1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ jobs:
         run: |
           WORKFLOW_ID=$(curl "Authorization: token ${{ github.token }}" https://api.github.com/repos/${{ github.repository }}/actions/workflows/windows.yml | jq '.id')
           echo "Workflow id: ${WORKFLOW_ID}"
-          echo "::set-env name=WORKFLOW_ID::${WORKFLOW_ID}"
+          echo "WORKFLOW_ID=${WORKFLOW_ID}" >> $GITHUB_ENV
 
       - uses: styfle/cancel-workflow-action@0.3.1
         with:


### PR DESCRIPTION
`set-env` is deprecated commands.
see: [GitHub Actions: Deprecating set-env and add-path commands](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)

Using [Setting an environment variable](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable).