### PR TITLE
Support conversion from integer to any char

### DIFF
--- a/src/library/Converters.nim
+++ b/src/library/Converters.nim
@@ -62,7 +62,7 @@ proc convertedValueToType*(x, y: Value, tp: ValueKind): Value =
                 case tp:
                     of Boolean: return newBoolean(y.i!=0)
                     of Floating: return newFloating((float)y.i)
-                    of Char: return newChar(chr(y.i))
+                    of Char: return newChar(toUTF8(Rune(y.i)))
                     of String: 
                         if y.iKind==NormalInteger: 
                             if (let aFormat = popAttr("format"); aFormat != VNULL):


### PR DESCRIPTION
# Description

This would make `to :char 20320` return `你` instead of junk char.

## Type of change

- [ ] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update