### PR TITLE
Combinatorics-related standard library functions

### DIFF
--- a/src/helpers/arrays.nim
+++ b/src/helpers/arrays.nim
@@ -103,35 +103,6 @@ func removeAll*(str: string, what: Value): string =
             elif item.kind == Char:
                 result = result.replace($(item.c))
 
-proc permutate*(s: ValueArray, emit: proc(emit:ValueArray) ) =
-    var s = @s
-    if s.len == 0: 
-        emit(s)
-        return
- 
-    var rc {.cursor} : proc(np: int)
-    rc = proc(np: int) = 
-
-        if np == 1: 
-            emit(s)
-            return
- 
-        var 
-            np1 = np - 1
-            pp = s.len - np1
- 
-        rc(np1) # recurs prior swaps
- 
-        for i in countDown(pp, 1):
-            swap s[i], s[i-1]
-            rc(np1) # recurs swap 
- 
-        let w = s[0]
-        s[0..<pp] = s[1..pp]
-        s[pp] = w
- 
-    rc(s.len)
-
 proc powerset*(s: HashSet[Value]): HashSet[HashSet[Value]] =
     result.incl(initHashSet[Value]())  # Initialized with empty set.
     for val in s:

--- a/src/helpers/combinatorics.nim
+++ b/src/helpers/combinatorics.nim
@@ -1,0 +1,49 @@
+######################################################
+# Arturo
+# Programming Language + Bytecode VM compiler
+# (c) 2019-2022 Yanis Zafirópulos
+#
+# @file: helpers/combinatorics.nim
+######################################################
+
+#=======================================
+# Libraries
+#=======================================
+
+import hashes, sets, strutils, tables, unicode
+
+import vm/values/comparison
+import vm/values/value
+
+#=======================================
+# Methods
+#=======================================
+
+proc permutate*(s: ValueArray, emit: proc(emit:ValueArray) ) =
+    var s = @s
+    if s.len == 0: 
+        emit(s)
+        return
+ 
+    var rc {.cursor} : proc(np: int)
+    rc = proc(np: int) = 
+
+        if np == 1: 
+            emit(s)
+            return
+ 
+        var 
+            np1 = np - 1
+            pp = s.len - np1
+ 
+        rc(np1) # recurs prior swaps
+ 
+        for i in countDown(pp, 1):
+            swap s[i], s[i-1]
+            rc(np1) # recurs swap 
+ 
+        let w = s[0]
+        s[0..<pp] = s[1..pp]
+        s[pp] = w
+ 
+    rc(s.len)

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -24,6 +24,7 @@ import strutils, sugar, unicode
     
 
 import helpers/arrays
+import helpers/combinatorics
 import helpers/regex
 import helpers/strings
 import helpers/unisort


### PR DESCRIPTION
# Description

Right now, we have `permutate` in the Collections module. 

**What has to be done:**

- `permutate` currently works on the entire sequence, and without repetitions; by default. This could be far more flexible
- in the exact same fashion, we could add another function, only this time for combinations (e.g. `combine` - not that this word is free, since the older `combine` has been renamed to `couple`, to avoid confusion)

## Type of change

- [x] Code cleanup
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update