### PR TITLE
Add .gitattributes for GitHub file highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 *.art linguist-language=Red
 *.art linguist-vendored
 tests/benchmarks/* linguist-vendored
+tests/errors/* linguist-vendored
+tests/unittests/* linguist-vendored
+examples/rosetta/* linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+*.art linguist-language=Red
+*.art linguist-vendored
 tests/benchmarks/* linguist-vendored


### PR DESCRIPTION
Render files on GitHub using the same Red linguist grammar as used in Markdown files