### PR TITLE
[VBinary] Made loop ops more memory efficient

### DIFF
--- a/src/vm/values/custom/vbinary.nim
+++ b/src/vm/values/custom/vbinary.nim
@@ -22,9 +22,9 @@ import strutils, sugar
 type 
     Byte* = byte
     VBinary*  = seq[Byte]
-
+    
 #=======================================
-# Overloads
+# Helpers
 #=======================================
 
 template loopOp(a, b: VBinary, op: untyped) =
@@ -33,6 +33,9 @@ template loopOp(a, b: VBinary, op: untyped) =
     for i in 0..result.high:
       result[i] = op(a[i], b[i])
 
+#=======================================
+# Overloads
+#=======================================
 
 proc `and`*(a, b: VBinary): VBinary =
     loopOp(a, b, `and`)

--- a/src/vm/values/custom/vbinary.nim
+++ b/src/vm/values/custom/vbinary.nim
@@ -27,14 +27,21 @@ type
 # Overloads
 #=======================================
 
-proc `and`*(a: VBinary, b: VBinary): VBinary =
-    zip(a, b).map((tup) => tup[0] and tup[1])
+template loopOp(a, b: VBinary, op: untyped) =
+  if 0 notin [a.len, b.len]:
+    result = newSeq[byte](min(a.high, b.high))
+    for i in 0..result.high:
+      result[i] = op(a[i], b[i])
+
+
+proc `and`*(a, b: VBinary): VBinary =
+    loopOp(a, b, `and`)
 
 proc `or`*(a: VBinary, b: VBinary): VBinary =
-    zip(a, b).map((tup) => tup[0] or tup[1])
+    loopOp(a, b, `or`)
 
 proc `xor`*(a: VBinary, b: VBinary): VBinary =
-    zip(a, b).map((tup) => tup[0] xor tup[1])
+    loopOp(a, b, `xor`)
 
 proc `not`*(a: VBinary): VBinary =
     a.map((w) => not w)


### PR DESCRIPTION
# Description
Stops using `sequtils` for binary ops which will reduce memory allocations a bit. Resulting in faster code when used.

Fixes # (issue/s)

## Type of change

- [X] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update