### PR TITLE
WIP: Reduced footprint of `Value` even further

### DIFF
--- a/src/library/Converters.nim
+++ b/src/library/Converters.nim
@@ -1064,21 +1064,21 @@ proc defineSymbols*() =
                                 else:
                                     options[k] = (vspec, "")
 
-                        ret.attrs() = options
+                        ret.attrs = options
 
                     if (let returnsData = y.data.d.getOrDefault("returns", nil); not returnsData.isNil):
                         if returnsData.kind==Type:
-                            ret.returns() = {returnsData.t}
+                            ret.returns = {returnsData.t}
                         else:
                             var returns: ValueSpec
                             for tp in returnsData.a:
                                 returns.incl(tp.t)
-                            ret.returns() = returns
+                            ret.returns = returns
 
                     if (let exampleData = y.data.d.getOrDefault("example", nil); not exampleData.isNil):
-                        ret.example() = exampleData.s
+                        ret.example = exampleData.s
     
-            ret.args() = argTypes
+            ret.args = argTypes
             
             push(ret)
 

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -274,11 +274,11 @@ proc execFunction*(fun: Value, fid: Hash) =
         # pop argument and set it
         SetSym(arg.s, move stack.pop())
 
-    if fun.bcode().isNil:
-        fun.bcode() = newBytecode(doEval(fun.main))
+    if fun.bcode.isNil:
+        fun.bcode = newBytecode(doEval(fun.main))
 
     try:
-        ExecLoop(fun.bcode().trans.constants, bcode(fun).trans.instructions)
+        ExecLoop(fun.bcode.trans.constants, bcode(fun).trans.instructions)
 
     except ReturnTriggered:
         discard

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -239,7 +239,7 @@ proc execFunction*(fun: Value, fid: Hash) =
     ##   pretty much like `execLeakless`
 
     var memoizedParams: Value = nil
-    var savedSyms: ValueDict
+    var savedSyms: ValueStackDict
 
     var savedArities = Arities
     let argsL = len(fun.params.a)
@@ -265,7 +265,7 @@ proc execFunction*(fun: Value, fid: Hash) =
             else:
                 Arities.del(arg.s)
         
-    savedSyms = Syms
+    savedSyms = Syms[]
     if not fun.imports.isNil:
         for k,v in pairs(fun.imports.d):
             SetSym(k, v)
@@ -308,10 +308,10 @@ proc execFunction*(fun: Value, fid: Hash) =
                         else:
                             savedArities.del(k.s)
             
-                Syms = savedSyms
+                Syms[] = savedSyms
                 Arities = savedArities
             else:
-                Syms = savedSyms
+                Syms[] = savedSyms
                 Arities = savedArities
 
 proc ExecLoop*(cnst: ValueArray, it: VBinary) =

--- a/src/vm/values/types.nim
+++ b/src/vm/values/types.nim
@@ -235,9 +235,13 @@ when sizeof(ValueObj) > 64: # At time of writing it was '56', 8 - 64 bit integer
     {.warning: "'Value's inner object is large which will impact performance".}
 
 template makeFuncAccessor*(name: untyped) =
-  template name*(val: Value): typeof(val.funcType.name) =
-    assert val.kind == Function
-    val.funcType.name
+    proc name*(val: Value): typeof(val.funcType.name) {.inline.} =
+        assert val.kind == Function
+        val.funcType.name
+
+    proc `name=`*(val: Value, newVal: typeof(val.funcType.name)) {.inline.} =
+        assert val.kind == Function
+        val.funcType.name = newVal
 
 
 makeFuncAccessor(args)

--- a/src/vm/values/value.nim
+++ b/src/vm/values/value.nim
@@ -646,7 +646,7 @@ proc copyValue*(v: Value): Value {.inline.} =
             else:
                 result = newBlock(v.a.map((vv)=>copyValue(vv)), copyValue(v.data))
 
-        of Dictionary:  result = newDictionary(v.d)
+        of Dictionary:  result = newDictionary(v.d[])
         of Object:      result = newObject(v.o, v.proto)
 
         of Function:    result = newFunction(v.params, v.main, v.imports, v.exports, v.exportable, v.memoize)

--- a/src/vm/values/value.nim
+++ b/src/vm/values/value.nim
@@ -269,10 +269,14 @@ func newVersion*(v: string): Value {.inline.} =
     extraPart &= v[lastIndex+1 .. ^1]
 
     let parts: seq[string] = numPart.split(".")
-    Value(kind: Version, major: parseInt(parts[0]), 
-                         minor: parseInt(parts[1]), 
-                         patch: parseInt(parts[2]), 
-                         extra: extraPart)
+    Value(kind: Version,
+        version: VVersion(
+            major: parseInt(parts[0]),
+            minor: parseInt(parts[1]),
+            patch: parseInt(parts[2]),
+            extra: extraPart
+        )
+    )
 
 func newType*(t: ValueKind): Value {.inline, enforceNoRaises.} =
     ## create Type (BuiltinType) value from ValueKind

--- a/src/vm/values/value.nim
+++ b/src/vm/values/value.nim
@@ -56,46 +56,51 @@ const
 # Fixed Values
 #=======================================
 
+template makeConst(v: Value): untyped =
+  var res = v
+  res.readOnly = true
+  res
+
 let
-    I0*             = Value(kind: Integer, iKind: NormalInteger, i: 0, readonly: true)      ## constant 0
-    I1*             = Value(kind: Integer, iKind: NormalInteger, i: 1, readonly: true)      ## constant 1
-    I2*             = Value(kind: Integer, iKind: NormalInteger, i: 2, readonly: true)      ## constant 2
-    I3*             = Value(kind: Integer, iKind: NormalInteger, i: 3, readonly: true)      ## constant 3
-    I4*             = Value(kind: Integer, iKind: NormalInteger, i: 4, readonly: true)      ## constant 4
-    I5*             = Value(kind: Integer, iKind: NormalInteger, i: 5, readonly: true)      ## constant 5
-    I6*             = Value(kind: Integer, iKind: NormalInteger, i: 6, readonly: true)      ## constant 6
-    I7*             = Value(kind: Integer, iKind: NormalInteger, i: 7, readonly: true)      ## constant 7
-    I8*             = Value(kind: Integer, iKind: NormalInteger, i: 8, readonly: true)      ## constant 8
-    I9*             = Value(kind: Integer, iKind: NormalInteger, i: 9, readonly: true)      ## constant 9
-    I10*            = Value(kind: Integer, iKind: NormalInteger, i: 10, readonly: true)     ## constant 10
-    I11*            = Value(kind: Integer, iKind: NormalInteger, i: 11, readonly: true)     ## constant 11
-    I12*            = Value(kind: Integer, iKind: NormalInteger, i: 12, readonly: true)     ## constant 12
-    I13*            = Value(kind: Integer, iKind: NormalInteger, i: 13, readonly: true)     ## constant 13
-    I14*            = Value(kind: Integer, iKind: NormalInteger, i: 14, readonly: true)     ## constant 14
-    I15*            = Value(kind: Integer, iKind: NormalInteger, i: 15, readonly: true)     ## constant 15
+    I0*             = makeConst Value(kind: Integer, iKind: NormalInteger, i: 0)      ## constant 0
+    I1*             = makeConst Value(kind: Integer, iKind: NormalInteger, i: 1)      ## constant 1
+    I2*             = makeConst Value(kind: Integer, iKind: NormalInteger, i: 2)      ## constant 2
+    I3*             = makeConst Value(kind: Integer, iKind: NormalInteger, i: 3)      ## constant 3
+    I4*             = makeConst Value(kind: Integer, iKind: NormalInteger, i: 4)      ## constant 4
+    I5*             = makeConst Value(kind: Integer, iKind: NormalInteger, i: 5)      ## constant 5
+    I6*             = makeConst Value(kind: Integer, iKind: NormalInteger, i: 6)      ## constant 6
+    I7*             = makeConst Value(kind: Integer, iKind: NormalInteger, i: 7)      ## constant 7
+    I8*             = makeConst Value(kind: Integer, iKind: NormalInteger, i: 8)      ## constant 8
+    I9*             = makeConst Value(kind: Integer, iKind: NormalInteger, i: 9)      ## constant 9
+    I10*            = makeConst Value(kind: Integer, iKind: NormalInteger, i: 10)     ## constant 10
+    I11*            = makeConst Value(kind: Integer, iKind: NormalInteger, i: 11)     ## constant 11
+    I12*            = makeConst Value(kind: Integer, iKind: NormalInteger, i: 12)     ## constant 12
+    I13*            = makeConst Value(kind: Integer, iKind: NormalInteger, i: 13)     ## constant 13
+    I14*            = makeConst Value(kind: Integer, iKind: NormalInteger, i: 14)     ## constant 14
+    I15*            = makeConst Value(kind: Integer, iKind: NormalInteger, i: 15)     ## constant 15
 
-    I1M*            = Value(kind: Integer, iKind: NormalInteger, i: -1, readonly: true)     ## constant -1
+    I1M*            = makeConst Value(kind: Integer, iKind: NormalInteger, i: -1)     ## constant -1
 
-    F0*             = Value(kind: Floating, f: 0.0, readonly: true)                         ## constant 0.0
-    F1*             = Value(kind: Floating, f: 1.0, readonly: true)                         ## constant 1.0
-    F2*             = Value(kind: Floating, f: 2.0, readonly: true)                         ## constant 2.0
+    F0*             = makeConst Value(kind: Floating, f: 0.0)                         ## constant 0.0
+    F1*             = makeConst Value(kind: Floating, f: 1.0)                         ## constant 1.0
+    F2*             = makeConst Value(kind: Floating, f: 2.0)                         ## constant 2.0
 
-    F1M*            = Value(kind: Floating, f: -1.0, readonly: true)                        ## constant -1.0
+    F1M*            = makeConst Value(kind: Floating, f: -1.0)                        ## constant -1.0
 
-    VTRUE*          = Value(kind: Logical, b: True, readonly: true)                         ## constant True
-    VFALSE*         = Value(kind: Logical, b: False, readonly: true)                        ## constant False
-    VMAYBE*         = Value(kind: Logical, b: Maybe, readonly: true)                        ## constant Maybe
+    VTRUE*          = makeConst Value(kind: Logical, flags: {isTrue})                         ## constant True
+    VFALSE*         = makeConst Value(kind: Logical, flags: {})                        ## constant False
+    VMAYBE*         = makeConst Value(kind: Logical, flags: {isMaybe})                        ## constant Maybe
 
-    VNULL*          = Value(kind: Null, readonly: true)                                     ## constant Null
+    VNULL*          = makeConst Value(kind: Null)                                     ## constant Null
 
-    VEMPTYSTR*      = Value(kind: String, s: "", readonly: true)                                    ## constant ""
-    VEMPTYARR*      = Value(kind: Block, a: @[], data: nil, readonly: true)                         ## constant []
-    VEMPTYDICT*     = Value(kind: Dictionary, d: initOrderedTable[string,Value](), readonly: true)  ## constant #[]
+    VEMPTYSTR*      = makeConst Value(kind: String, s: "")                                    ## constant ""
+    VEMPTYARR*      = makeConst Value(kind: Block, a: @[], data: nil)                         ## constant []
+    VEMPTYDICT*     = makeConst Value(kind: Dictionary, d: initOrderedTable[string,Value]())  ## constant #[]
 
-    VSTRINGT*       = Value(kind: Type, tpKind: BuiltinType, t: String, readonly: true)     ## constant ``:string``
-    VINTEGERT*      = Value(kind: Type, tpKind: BuiltinType, t: Integer, readonly: true)    ## constant ``:integer``
+    VSTRINGT*       = makeConst Value(kind: Type, tpKind: BuiltinType, t: String)     ## constant ``:string``
+    VINTEGERT*      = makeConst Value(kind: Type, tpKind: BuiltinType, t: Integer)    ## constant ``:integer``
 
-    VNOTHING*       = Value(kind: Nothing, readonly: true)                                  ## constant Nothing
+    VNOTHING*       = makeConst Value(kind: Nothing)                                  ## constant Nothing
 
     #--------
 
@@ -540,11 +545,21 @@ func newBytecode*(t: sink Translation): Value {.inline, enforceNoRaises.} =
 
 func newInline*(a: sink ValueArray = @[], dirty = false): Value {.inline, enforceNoRaises.} =
     ## create Inline value from ValueArray
-    Value(kind: Inline, a: a, dirty: dirty)
+    let flags =
+      if dirty:
+          {isDirty}
+      else:
+          {}
+    Value(kind: Inline, a: a, flags: flags)
 
 func newBlock*(a: sink ValueArray = @[], data: sink Value = nil, dirty = false): Value {.inline, enforceNoRaises.} =
     ## create Block value from ValueArray
-    Value(kind: Block, a: a, data: data, dirty: dirty)
+    let flags =
+      if dirty:
+          {isDirty}
+      else:
+          {}
+    Value(kind: Block, a: a, data: data, flags: flags)
 
 func newIntegerBlock*[T](a: sink seq[T]): Value {.inline, enforceNoRaises.} =
     ## create Block value from an array of ints


### PR DESCRIPTION
# Description

Following more investigations I looked at making `Value` even smaller, but this pass might result in slower performance for objects/dictionaries so benchmarks really need to be looked at. Presently on a 64bit machine Value is now 32bytes instead of 56.
```
Benchmark 1: arturo ./integer_increment_inc_inplace_1m.art
  Time (mean ± σ):     249.9 ms ±   8.0 ms    [User: 215.9 ms, System: 33.6 ms]
  Range (min … max):   242.5 ms … 269.4 ms    11 runs

Benchmark 1: arturo-fast ./integer_increment_inc_inplace_1m.art
  Time (mean ± σ):     239.6 ms ±   3.8 ms    [User: 214.7 ms, System: 24.6 ms]
  Range (min … max):   236.2 ms … 250.3 ms    12 runs

Benchmark 1: arturo ./dictionary_lookup_1m.art
  Time (mean ± σ):     456.4 ms ±   7.5 ms    [User: 395.5 ms, System: 58.5 ms]
  Range (min … max):   449.8 ms … 472.2 ms    10 runs

Benchmark 1: arturo-fast ./dictionary_lookup_1m.art
  Time (mean ± σ):     437.9 ms ±   2.6 ms    [User: 395.2 ms, System: 42.1 ms]
  Range (min … max):   435.8 ms … 442.7 ms    10 runs
```

Some memory looks:
```
/usr/local/bin/time -v arturo ./array_access_1m.art
Maximum resident set size (kbytes): 634336

/usr/local/bin/time -v arturo-fast ./array_access_1m.art
Maximum resident set size (kbytes): 476692

/usr/local/bin/time -v arturo ./integer_increment_1m.art
Maximum resident set size (kbytes): 617996

/usr/local/bin/time -v arturo-fast ./integer_increment_1m.art
Maximum resident set size (kbytes): 460448
```

Addresses some parts of https://github.com/arturo-lang/arturo/issues/795

Fixes # (issue/s)

## Type of change

- [x] Code cleanup
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update