### PR TITLE
fix: can't compile in MSYS2/Mingw64 on windows 10 64bits

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -10,7 +10,7 @@ switch("hints","off")
 
 if hostOS=="windows":
     switch("gcc.path", normalizedPath(
-        staticExec("pkg-config --libs-only-L gmp").strip()
+        staticExec("/usr/bin/pkg-config --libs-only-L gmp").strip()
                                                   .replace("-L","")
                                                   .replace("/lib","/bin")
         )


### PR DESCRIPTION
# Description

I read [this issue](https://github.com/arturo-lang/arturo/issues/837) and tried to build Arturo in my machine, but I had an error, as I said [here](https://github.com/arturo-lang/arturo/issues/837#issuecomment-1339761080).
I tried a lot of ways to fix it, and I finally found one.

This PR changes just one line inside of `if hostOS=="windows"`, so It must not change anything for the others Operational Systems.

This was the way I found to build locally on my machine.

> Fixes #837

As I said, it's working on my local machine. So I'll wait for CI.
Thanks @retsyo for report this issue!

### Build Info

```
--------------------------------------------
 ��� Checking environment...
--------------------------------------------
   os: windows
   compiler: Nim v1.6.6

--------------------------------------------
 ��� Building...
--------------------------------------------
   version: 0.9.80 b/3298
   config: @mini
   flags: --skipUserCfg:on --colors:off -d:danger --panics:off --mm:orc -d:useMalloc --checks:off -d:ssl --cincludes:extras --opt:speed --nimcache:.cache --path:src   -d:NOASCIIDECODE -d:NOCLIPBOARD -d:NODIALOGS -d:NOGMP -d:NOPARSERS -d:NOSQLITE
-d:NOWEBVIEW -d:MINI
```
And
```
--------------------------------------------
 ��� Checking environment...
--------------------------------------------
   os: windows
   compiler: Nim v1.6.6

--------------------------------------------
 ��� Building...
--------------------------------------------
   version: 0.9.80 b/3298
   config: @full
   flags: --skipUserCfg:on --colors:off -d:danger --panics:off --mm:orc -d:useMalloc --checks:off -d:ssl --cincludes:extras --opt:speed --nimcache:.cache --path:src
```

As you can see, I'm building on 0.9.80 b/3298 version, using nim 1.6.6

### Additional Notes

I built it on VsCodium that was not reading `PKG_CONFIG_PATH`, so none needs to be changed with this variable.
Other times ago on Msys2, I tried to change the `PKG_CONFIG_PATH` to right path and then build. `pkg-config` command was working, but the build was not, giving me [this same error](https://github.com/arturo-lang/arturo/issues/837#issuecomment-1339761080).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)