### PR TITLE
Adds FFI example to call function

### DIFF
--- a/src/library/Core.nim
+++ b/src/library/Core.nim
@@ -129,23 +129,22 @@ proc defineSymbols*() =
             ..........
             call $[x][x+2] [5]            ; 7
             ..........
-            // Let's say you want to call external functions:
-            //
-            // mylib.c
-            // compile with:
-            // clang -c -w mylib.c
-            // clang -shared -o libmylib.dylib mylib.o
+            ; Calling external (C code) functions
+            
+            ; compile with:
+            ; clang -c -w mylib.c
+            ; clang -shared -o libmylib.dylib mylib.o
+            
+            ; #include <stdio.h>
+            ;
+            ; void sayHello(char* name){
+            ;    printf("Hello %s!\n", name);
+            ; }
+            ;
+            ; int doubleNum(int num){
+            ;    return num * 2;
+            ;}
 
-            #include <stdio.h>
-
-            void sayHello(char* name){
-                printf("Hello %s!\n", name);
-            }
-
-            int doubleNum(int num){
-                return num * 2;
-            }
-            ..........
             ; call an external function directly
             call.external: "mylib" 'sayHello ["John"]
 

--- a/src/library/Core.nim
+++ b/src/library/Core.nim
@@ -128,6 +128,38 @@ proc defineSymbols*() =
             call 'multiply [3 5]          ; => 15
             ..........
             call $[x][x+2] [5]            ; 7
+            ..........
+            // Let's say you want to call external functions:
+            //
+            // mylib.c
+            // compile with:
+            // clang -c -w mylib.c
+            // clang -shared -o libmylib.dylib mylib.o
+
+            #include <stdio.h>
+
+            void sayHello(char* name){
+                printf("Hello %s!\n", name);
+            }
+
+            int doubleNum(int num){
+                return num * 2;
+            }
+            ..........
+            ; call an external function directly
+            call.external: "mylib" 'sayHello ["John"]
+
+            ; map an external function to a native one
+            doubleNum: function [num][
+                ensure -> integer? num
+                call .external: "mylib"
+                    .expect:   :integer
+                    'doubleNum @[num]
+            ]
+
+            loop 1..3 'x [
+                print ["The double of" x "is" doubleNum x]
+            ]
         """:
             #=======================================================
             if checkAttr("external"):


### PR DESCRIPTION
# Description

Adds missing example of how to properly use FFI in Arturo.
>Note: It'll cover both `.expect` and `.external` 

The current documentation does not cover this feature, and I had to search into Rosetta examples to discover how to use it:
[call a foreign-language function.c](https://github.com/arturo-lang/arturo/blob/master/examples/rosetta/call%20a%20foreign-language%20function.c)
[call a foreign-language function.art](https://github.com/arturo-lang/arturo/blob/master/examples/rosetta/call%20a%20foreign-language%20function.art)

## Type of change

- [x] This change requires a documentation update