### PR TITLE
[Collections/remove] fixing `.once` behavior

### DIFF
--- a/src/helpers/arrays.nim
+++ b/src/helpers/arrays.nim
@@ -40,12 +40,20 @@ func removeFirst*(str: string, what: string): string =
         result = str
 
 proc removeFirst*(arr: ValueArray, what: Value): ValueArray =
-    var searching = true
-    for v in arr:
-        if searching and v==what:
-            searching = false
-        else:
-            result.add(v)
+    if what.kind==Block:
+        var to_remove = toHashSet(what.a)
+        for v in arr:
+            if to_remove.contains(v):
+                to_remove.excl(v)
+            else:
+                result.add(v)
+    else:
+        var searching = true
+        for v in arr:
+            if searching and v==what:
+                searching = false
+            else:
+                result.add(v)
 
 proc removeAll*(arr: ValueArray, what: Value): ValueArray =
     if what.kind==Block:

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -1161,6 +1161,10 @@ proc defineSymbols*() =
             ..........
             print remove.once "hello" "l"
             ; helo
+            
+            ; Use remove.once to remove just once each element from value
+            remove.once  [1 2 [1 2] 3 4 1 2 [1 2] 3 4]  [1 2]
+            ; [[1 2] 3 4 1 2 [1 2] 3 4]
             ..........
             remove [1 2 3 4] 4        ; => [1 2 3]
         """:

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -1162,7 +1162,7 @@ proc defineSymbols*() =
             print remove.once "hello" "l"
             ; helo
             
-            ; Use remove.once to remove just once each element from value
+            ; Remove each element of given block from collection once
             remove.once  [1 2 [1 2] 3 4 1 2 [1 2] 3 4]  [1 2]
             ; [[1 2] 3 4 1 2 [1 2] 3 4]
             ..........

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -470,6 +470,9 @@ do [
         debug remove.once [1 6 2 5 3 4 5 6] [5 2]
         debug remove.once [1 [6 2] 5 3 4 5 6] [6 2]
 
+        ; Testing new behavior from PR #877
+        debug remove.once [1 2 [1 2] 3 4 1 2 [1 2] 3 4]  [1 2]
+
         ; try with char
         debug remove.once "hello" `l`
 

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -1,3 +1,4 @@
+
 >> append
 
 
@@ -209,8 +210,9 @@ helo :string
 [1 2 3 4 5] :block 
 helo :string 
 [1 2 3 4 5] :block 
-[1 6 2 5 3 4 5 6] :block 
-[1 5 3 4 5 6] :block 
+[1 6 3 4 5 6] :block 
+[1 [6 2] 5 3 4 5] :block 
+[[1 2] 3 4 1 2 [1 2] 3 4] :block 
 hello :string 
 
 >> repeat
@@ -328,4 +330,4 @@ true
 
 >> values
 
-[John Doe 012568 Manchester 45] :block
+[John Doe 012568 Manchester 45] :block 


### PR DESCRIPTION
# Description
Fix the behavior according to #876

Fixes #876 

Running on my local build:
![image](https://user-images.githubusercontent.com/78623871/208194478-cc742b9d-d758-472f-aa12-a67db245c102.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Add/Update unit tests
- [x] Add/Update usage example

## Requires

- [ ] Documentation update
- [ ] Build update
- [x] Unit test output update
