### PR TITLE
Add support of module function for windows

### DIFF
--- a/src/library/Paths.nim
+++ b/src/library/Paths.nim
@@ -258,7 +258,10 @@ proc defineSymbols*() =
             do module 'html    ; (imports given module)
             """:
                 #=======================================================
-                push(newString(HomeDir & ".arturo/lib/" & x.s & ".art"))
+                when defined(windows):
+                    push(newString(HomeDir & ".arturo\\lib\\" & x.s & ".art"))
+                else:
+                    push(newString(HomeDir & ".arturo/lib/" & x.s & ".art"))
         
         builtin "normalize",
             alias       = dotslash, 


### PR DESCRIPTION
It's not so important because `module` should be replaced on future. But, for while, why not fix it temporarily? 🙂 

Fixes #878

My local build:
![image](https://user-images.githubusercontent.com/78623871/208244767-9e3a4fa0-a07e-4112-b030-a4a12093ad97.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)