### PR TITLE
[Collections/split] fix `.path` behavior (including bug on Windows)

### DIFF
--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -1807,7 +1807,7 @@ proc defineSymbols*() =
                 elif (hadAttr("lines")):
                     push(newStringBlock(x.s.splitLines()))
                 elif (hadAttr("path")):
-                    push(newStringBlock(x.s.split(DirSep)))
+                    push(newStringBlock(x.s.split({DirSep, AltSep})))
                 elif checkAttr("by"):
                     if aBy.kind == String:
                         push(newStringBlock(x.s.split(aBy.s)))

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -1760,7 +1760,10 @@ proc defineSymbols*() =
                     elif (hadAttr("lines")):
                         SetInPlace(newStringBlock(InPlaced.s.splitLines()))
                     elif (hadAttr("path")):
-                        SetInPlace(newStringBlock(InPlaced.s.split(DirSep)))
+                        when defined(windows):
+                            SetInPlace(newStringBlock(InPlaced.s.split({'/', '\\'})))
+                        else:
+                            SetInPlace(newStringBlock(InPlaced.s.split(DirSep)))
                     elif checkAttr("by"):
                         if aBy.kind == String:
                             SetInPlace(newStringBlock(InPlaced.s.split(aBy.s)))

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -1760,7 +1760,13 @@ proc defineSymbols*() =
                     elif (hadAttr("lines")):
                         SetInPlace(newStringBlock(InPlaced.s.splitLines()))
                     elif (hadAttr("path")):
-                        SetInPlace(newStringBlock(InPlaced.s.split({DirSep, AltSep})))
+                        var strStart = 0
+                        var strEnd = 1
+                        if InPlaced.s.startsWith(DirSep) or InPlaced.s.startsWith(AltSep):
+                            strStart = 1
+                        if InPlaced.s.endsWith(DirSep) or InPlaced.s.endsWith(AltSep):
+                            strEnd = 2
+                        SetInPlace(newStringBlock(InPlaced.s[strStart..^strEnd].split({DirSep,AltSep})))
                     elif checkAttr("by"):
                         if aBy.kind == String:
                             SetInPlace(newStringBlock(InPlaced.s.split(aBy.s)))
@@ -1807,7 +1813,13 @@ proc defineSymbols*() =
                 elif (hadAttr("lines")):
                     push(newStringBlock(x.s.splitLines()))
                 elif (hadAttr("path")):
-                    push(newStringBlock(x.s.split({DirSep, AltSep})))
+                    var strStart = 0
+                    var strEnd = 1
+                    if x.s.startsWith(DirSep) or x.s.startsWith(AltSep):
+                        strStart = 1
+                    if x.s.endsWith(DirSep) or x.s.endsWith(AltSep):
+                        strEnd = 2
+                    push(newStringBlock(x.s[strStart..^strEnd].split({DirSep,AltSep})))
                 elif checkAttr("by"):
                     if aBy.kind == String:
                         push(newStringBlock(x.s.split(aBy.s)))

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -1760,10 +1760,7 @@ proc defineSymbols*() =
                     elif (hadAttr("lines")):
                         SetInPlace(newStringBlock(InPlaced.s.splitLines()))
                     elif (hadAttr("path")):
-                        when defined(windows):
-                            SetInPlace(newStringBlock(InPlaced.s.split({'/', '\\'})))
-                        else:
-                            SetInPlace(newStringBlock(InPlaced.s.split(DirSep)))
+                        SetInPlace(newStringBlock(InPlaced.s.split({DirSep, AltSep})))
                     elif checkAttr("by"):
                         if aBy.kind == String:
                             SetInPlace(newStringBlock(InPlaced.s.split(aBy.s)))

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -702,28 +702,21 @@ do [
 
     debug split [[1 2 3] [4 5 6] [7 8]]
 
-    currentOS: sys\["os"]
-    if? "windows" = currentOS [
 
-        debug split.path "directory\\wofilerld"
+    debug split.path "directory\\wofilerld"
+    debug split.path "D:\\User\\user\\.arturo"
+    debug split.path "/usr/bin"
 
-        p1: "User/user/.arturo"
-        p2: "\\usr\\bin" 
+    p1: "directory\\wofilerld"
+    p2: "D:\\User\\user\\.arturo"
+    p3: "/usr/bin"
 
-        debug split.path p1
-        split.path 'p2, debug p2
-
-    ] else [
-
-        debug split.path "directory/wofilerld"
-
-        p1: "User/user/.arturo"
-        p2: "/usr/bin"
-
-        debug split.path p1
-        split.path 'p2, debug p2
-
-    ]
+    debug split.path p1
+    debug split.path p2
+    debug split.path p3
+    split.path 'p1, debug p1
+    split.path 'p2, debug p2
+    split.path 'p3, debug p3
 
     ; Testing Attributes
     debug split.words "Hello World!"

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -703,13 +703,19 @@ do [
     debug split [[1 2 3] [4 5 6] [7 8]]
 
 
-    debug split.path "directory\\wofilerld"
-    debug split.path "D:\\User\\user\\.arturo"
-    debug split.path "/usr/bin"
+    (sys\os = "windows")? [
+        debug split.path "directory\\wofilerld"
+        debug split.path "\\usr\\bin"
 
-    p1: "directory\\wofilerld"
-    p2: "D:\\User\\user\\.arturo"
-    p3: "/usr/bin"
+        p1: "directory\\wofilerld"
+        p2: "\\usr\\bin"
+    ][
+        debug split.path "directory/wofilerld"
+        debug split.path "/usr/bin"
+
+        p1: "directory/wofilerld"
+        p2: "/usr/bin"
+    ]
 
     debug split.path p1
     debug split.path p2

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -707,13 +707,13 @@ do [
         debug split.path "directory\\wofilerld"
         debug split.path "\\usr\\bin"
 
-        p1: "directory\\wofilerld"
+        p1: "directory\\wofilerld\\"
         p2: "\\usr\\bin"
     ][
         debug split.path "directory/wofilerld"
         debug split.path "/usr/bin"
 
-        p1: "directory/wofilerld"
+        p1: "directory/wofilerld/"
         p2: "/usr/bin"
     ]
 
@@ -725,7 +725,9 @@ do [
     ; tests the Unix's default path and Windows' alternative
     ; Since, you can use it on Msys, for instance
     ; it gives the same result in both
+    debug split.path "/usr/bin/"
     debug split.path "/usr/bin"
+    debug split.path "usr/bin/"
 
     ; Testing Attributes
     debug split.words "Hello World!"

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -715,7 +715,7 @@ do [
 
     ] else [
 
-        debug split.path "directory\\wofilerld"
+        debug split.path "directory/wofilerld"
 
         p1: "User/user/.arturo"
         p2: "/usr/bin"

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -719,10 +719,8 @@ do [
 
     debug split.path p1
     debug split.path p2
-    debug split.path p3
     split.path 'p1, debug p1
     split.path 'p2, debug p2
-    split.path 'p3, debug p3
 
     ; Testing Attributes
     debug split.words "Hello World!"

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -722,6 +722,11 @@ do [
     split.path 'p1, debug p1
     split.path 'p2, debug p2
 
+    ; tests the Unix's default path and Windows' alternative
+    ; Since, you can use it on Msys, for instance
+    ; it gives the same result in both
+    debug split.path "/usr/bin"
+
     ; Testing Attributes
     debug split.words "Hello World!"
 

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -704,9 +704,25 @@ do [
 
     currentOS: sys\["os"]
     if? "windows" = currentOS [
+
         debug split.path "directory\\wofilerld"
+
+        p1: "User/user/.arturo"
+        p2: "\\usr\\bin" 
+
+        debug split.path p1
+        split.path 'p2, debug p2
+
     ] else [
-        debug split.path "directory/wofilerld"
+
+        debug split.path "directory\\wofilerld"
+
+        p1: "User/user/.arturo"
+        p2: "/usr/bin"
+
+        debug split.path p1
+        split.path 'p2, debug p2
+
     ]
 
     ; Testing Attributes

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -702,10 +702,12 @@ do [
 
     debug split [[1 2 3] [4 5 6] [7 8]]
 
-    ;path
-    ; temporarily disable
-    ; see issue: #872
-    ; debug split.path "directory/wofilerld"
+    currentOS: sys\["os"]
+    if? "windows" = currentOS [
+        debug split.path "directory\\wofilerld"
+    ] else [
+        debug split.path "directory/wofilerld"
+    ]
 
     ; Testing Attributes
     debug split.words "Hello World!"

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -311,12 +311,14 @@ Art :string
 [A r t u r o] :block 
 [[1 2 3] [4 5 6] [7 8]] :block 
 [directory wofilerld] :block 
-[ usr bin] :block 
+[usr bin] :block 
 [directory wofilerld] :block 
-[ usr bin] :block 
+[usr bin] :block 
 [directory wofilerld] :block 
-[ usr bin] :block 
-[ usr bin] :block 
+[usr bin] :block 
+[usr bin] :block 
+[usr bin] :block 
+[usr bin] :block 
 [Hello World!] :block 
 [Hi my name is...] :block 
 [directory file.ext] :block 

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -311,13 +311,10 @@ Art :string
 [A r t u r o] :block 
 [[1 2 3] [4 5 6] [7 8]] :block 
 [directory wofilerld] :block 
-[D: User user .arturo] :block 
 [ usr bin] :block 
 [directory wofilerld] :block 
-[D: User user .arturo] :block 
 [ usr bin] :block 
 [directory wofilerld] :block 
-[D: User user .arturo] :block 
 [ usr bin] :block 
 [Hello World!] :block 
 [Hi my name is...] :block 

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -310,6 +310,7 @@ Art :string
 
 [A r t u r o] :block 
 [[1 2 3] [4 5 6] [7 8]] :block 
+[directory wofilerld] :block 
 [Hello World!] :block 
 [Hi my name is...] :block 
 [directory file.ext] :block 

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -316,6 +316,7 @@ Art :string
 [ usr bin] :block 
 [directory wofilerld] :block 
 [ usr bin] :block 
+[ usr bin] :block 
 [Hello World!] :block 
 [Hi my name is...] :block 
 [directory file.ext] :block 

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -311,6 +311,8 @@ Art :string
 [A r t u r o] :block 
 [[1 2 3] [4 5 6] [7 8]] :block 
 [directory wofilerld] :block 
+[User user .arturo] :block 
+[ usr bin] :block 
 [Hello World!] :block 
 [Hi my name is...] :block 
 [directory file.ext] :block 

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -311,7 +311,13 @@ Art :string
 [A r t u r o] :block 
 [[1 2 3] [4 5 6] [7 8]] :block 
 [directory wofilerld] :block 
-[User user .arturo] :block 
+[D: User user .arturo] :block 
+[ usr bin] :block 
+[directory wofilerld] :block 
+[D: User user .arturo] :block 
+[ usr bin] :block 
+[directory wofilerld] :block 
+[D: User user .arturo] :block 
 [ usr bin] :block 
 [Hello World!] :block 
 [Hi my name is...] :block 


### PR DESCRIPTION
# Description

Adds support for windows path style.
For windows, both `\\` and `/` will be processed.

Fixes #878

On my local build:
![image](https://user-images.githubusercontent.com/78623871/208243939-251774b1-4f23-4519-a2c6-4e26e2293b3c.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Add/Update unit tests

## Requires
- [ ] Build update
- [x] Unit test output update
