### PR TITLE
[Collections/slice] make it work with literals

### DIFF
--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -1528,7 +1528,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "get a slice of collection between given indices",
         args        = {
-            "collection": {String, Block},
+            "collection": {String, Block, Literal},
             "from"      : {Integer},
             "to"        : {Integer}
         },
@@ -1540,7 +1540,18 @@ proc defineSymbols*() =
             print slice 1..10 3 4         ; 4 5
         """:
             #=======================================================
-            if x.kind == String:
+            if x.kind == Literal:
+                ensureInPlace()
+                if InPlaced.kind == String:
+                    if InPlaced.s.len == 0:
+                        SetInPlace newString("")
+                    else:
+                        if y.i >= 0 and z.i <= InPlaced.s.runeLen:
+                            SetInPlace newString Inplaced.s.runeSubStr(y.i, z.i - y.i + 1)
+                else:
+                    if y.i >= 0 and z.i <= InPlaced.a.len-1:
+                        InPlaced.a = InPlaced.a[y.i..z.i]
+            elif x.kind == String:
                 if x.s.len == 0: push(newString(""))
                 else:
                     if y.i >= 0 and z.i <= x.s.runeLen:

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -1521,8 +1521,6 @@ proc defineSymbols*() =
             else: # Null
                 push(newInteger(0))
 
-    # TODO(Collections/slice) could also work with literal values
-    #  labels: library, enhancement
     builtin "slice",
         alias       = unaliased,
         rule        = PrefixPrecedence,

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -598,9 +598,13 @@ topic "slice"
 do [
 
     debug slice "Arturo" 0 2
+    debug slice ["Arturo" "Python" "Ruby" "C" "C++" "Nim" "Wren"] 3 5
 
-    compiled: slice ["Arturo" "Python" "Ruby" "C" "C++" "Nim" "Wren"] 3 5
-    debug compiled
+    a: ["Arturo" "Python" "Ruby" "C" "C++" "Nim" "Wren"]
+    b: "Arturo"
+
+    slice 'a 3 5, debug a
+    slice 'b 0 2, debug b
 
 ]
 

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -270,6 +270,8 @@ true
 
 Art :string 
 [C C++ Nim] :block 
+[C C++ Nim] :block 
+Art :string 
 
 >> sort
 


### PR DESCRIPTION
# Description

Add literal support to slice functions.

Fixes #844

Running on my local build:
![image](https://user-images.githubusercontent.com/78623871/208251935-d22f098e-d745-4cd4-a735-5a6a10e36fd3.png)


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Add/Update unit tests

## Required changes
- [ ] Build update
- [x] Unit test output update 
