### PR TITLE
[Collections/split] `.by` not working properly with Literal values?

### DIFF
--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -745,6 +745,10 @@ do [
 
     debug split.by: "/" "directory/file.ext"
 
+    csv: "id;nickname;name;age"
+    split.by: ";" 'csv
+    debug csv
+
     debug split.at: 5 "Hello, World"
     debug split.at: 4 [
         "Arnold" "Andreas" "Paul" "Ricard" "Linus"

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -326,6 +326,7 @@ Art :string
 [Hello World!] :block 
 [Hi my name is...] :block 
 [directory file.ext] :block 
+[id nickname name age] :block 
 [Hello , World] :block 
 [[Arnold Andreas Paul Ricard] [Linus Yanis Helena Eva Blanca]] :block 
 [spl it  col lec tio n t o c omp one nts] :block 


### PR DESCRIPTION
# Description

So, `split.by` is working well at the `master` version. So, I just updated the unit-test to cover it.
Also, I'll open a new issue about the `split.every`.

Fixes #871 

## Type of change
- [x] Add/Update unit tests

## Requires
- [x] Unit test output update