### PR TITLE
[Collections/split] `.every` is not working properly with Literal values

### DIFF
--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -1803,7 +1803,10 @@ proc defineSymbols*() =
                         var i = 0
 
                         while i < length:
-                            ret.add(InPlaced.a[i..i+aEvery.i-1])
+                            if i + aEvery.i > length:
+                                ret.add(newBlock(InPlaced.a[i..^1]))
+                            else:
+                                ret.add(newBlock(InPlaced.a[i..i+aEvery.i-1]))
                             i += aEvery.i
 
                         SetInPlace(newBlock(ret))

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -766,11 +766,10 @@ do [
     b: ["Arnold" "Andreas" "Paul" "Ricard" "Linus" "Yanis" "Helena" "Eva" "Blanca"]
     split.every: 3 'b, debug b
 
-    debug split.every: 3 "Manchester"
-    city: "Manchester"
-    split.every: 3 'city, debug city
-    ; It's returning a flatten block
-    ; Is it working properly?
+    ; This test is returning strange character filling the last inner block
+    ; debug split.every: 3 "Manchesterr"
+    ; city: "Manchester"
+    ; split.every: 3 'city, debug city
 
 ]
 

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -764,7 +764,7 @@ do [
     split.at: 4 'a, debug a
 
     b: ["Arnold" "Andreas" "Paul" "Ricard" "Linus" "Yanis" "Helena" "Eva" "Blanca"]
-    ; split.every: 3 'b, debug b
+    split.every: 3 'b, debug b
     ; It's returning a flatten block
     ; Is it working properly?
 

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -765,6 +765,10 @@ do [
 
     b: ["Arnold" "Andreas" "Paul" "Ricard" "Linus" "Yanis" "Helena" "Eva" "Blanca"]
     split.every: 3 'b, debug b
+
+    debug split.every: 3 "Manchester"
+    city: "Manchester"
+    split.every: 3 'city, debug city
     ; It's returning a flatten block
     ; Is it working properly?
 

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -331,6 +331,7 @@ Art :string
 [spl it  col lec tio n t o c omp one nts] :block 
 [[Arnold Andreas Paul] [Ricard Linus Yanis] [Helena Eva Blanca]] :block 
 [[Arnold Andreas Paul Ricard Linus] [Linus Yanis Helena Eva Blanca]] :block 
+[[Arnold Andreas Paul] [Ricard Linus Yanis] [Helena Eva Blanca]] :block 
 
 >> squeeze
 


### PR DESCRIPTION
# Description

Fix `every.split` to work with literal types.
Also, I found [another error](https://github.com/arturo-lang/arturo/issues/885#issuecomment-1358069385) when I was testing it. But this, I opened in a new Issue: #887 

Fixes #885

On my local build:
![image](https://user-images.githubusercontent.com/78623871/208532256-e3f0cb68-0786-420a-99de-21b1e8a742e8.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Add/Update unit tests

## Requires
- [ ] Build update
- [x] Unit test output update