### PR TITLE
[Collections/split] `.every` is not working properly with String values

### DIFF
--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -1785,11 +1785,16 @@ proc defineSymbols*() =
                         var length = InPlaced.s.len
                         var i = 0
 
-                        while i < length:
-                            ret.add(InPlaced.s[i..i+aEvery.i-1])
-                            i += aEvery.i
+                        while i <= length:
+                            if i + aEvery.i <= length:
+                                ret.add(InPlaced.s[i..i+aEvery.i-1])
+                                i += aEvery.i
+                            else:
+                                ret.add(InPlaced.s[i..^1])
+                                i += aEvery.i
 
                         SetInPlace(newStringBlock(ret))
+
                     else:
                         SetInPlace(newStringBlock(toSeq(runes(x.s)).map((x) =>
                                 $(x))))
@@ -1837,10 +1842,15 @@ proc defineSymbols*() =
                     var i = 0
 
                     while i < length:
-                        ret.add(x.s[i..i+aEvery.i-1])
-                        i += aEvery.i
+                        if i + aEvery.i <= length:
+                            ret.add(x.s[i..i+aEvery.i-1])
+                            i += aEvery.i
+                        else:
+                            ret.add(x.s[i..^1])
+                            i += aEvery.i
 
                     push(newStringBlock(ret))
+                
                 else:
                     push(newStringBlock(toSeq(runes(x.s)).map((x) => $(x))))
             else:

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -768,6 +768,19 @@ do [
     ; It's returning a flatten block
     ; Is it working properly?
 
+    city: split.every: 3 "Manchester"
+    print [city, size city\0, size city\1, size city\2, size city\3]
+
+    lang: split.every: 4 "Arturo"
+    print [lang, size lang\0, size lang\1]
+
+    city2: "Manchester"
+    lang2: "Arturo"
+    split.every: 3 'city2
+    split.every: 4 'lang2
+    print [city2, size city2\0, size city2\1, size city2\2, size city2\3]
+    print [lang2, size lang2\0 size, lang2\1]
+
 ]
 
 

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -331,6 +331,10 @@ Art :string
 [spl it  col lec tio n t o c omp one nts] :block 
 [[Arnold Andreas Paul] [Ricard Linus Yanis] [Helena Eva Blanca]] :block 
 [[Arnold Andreas Paul Ricard Linus] [Linus Yanis Helena Eva Blanca]] :block 
+[Man che ste r] 3 3 3 1 
+[Artu ro] 4 2 
+[Man che ste r] 3 3 3 1 
+[Artu ro] 4 2 
 
 >> squeeze
 


### PR DESCRIPTION
# Description
The current implementation on master is returning strings with same size of `every` attribute.
It's not wrong for strings at the start or middle of the block, and some cases also not wrong at the end.
BUT, for some strings divided by certain numbers, the last item will return with wrong size
So, I fixed it to return the right size.

**Example**
*Current implementation:*
```
; This code
split.every: 3 "Manchester"
; returns a block with:
; [Man che ste r]
; string of size 3, string of size 3, string of size 3 and string of size 3???
```

The real case of this problem is described on issue #887 

*The new implementation*
```
; This code
split.every: 3 "Manchester"
; returns a block with:
; ; [Man che ste r]
; stringsof size 3, string of size 3, string of size 3 and string of size 1
```

The current implementation was putting wrong chars at the last block, since it was pushing a whole `every` size per block without any flexibility.

Fixes #887

## At my local build:
![image](https://user-images.githubusercontent.com/78623871/208528700-873f6e3c-43c1-4417-8938-ccb45e412abf.png)
![image](https://user-images.githubusercontent.com/78623871/208528719-be95136b-3a05-4738-9575-0c22f38bdacf.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Add/Update unit-tests

## Requires
- [ ] Build update
- [x] Unit test output update