### PR TITLE
[Files/read] add support for different delimiters when in `.csv` mode

### DIFF
--- a/src/helpers/csv.nim
+++ b/src/helpers/csv.nim
@@ -18,14 +18,14 @@ import vm/values/value
 # Methods
 #=======================================
 
-proc parseCsvInput*(input: string, withHeaders: bool = false): Value =
+proc parseCsvInput*(input: string, withHeaders: bool = false, withDelimiter: char = ','): Value =
     var x: CsvParser
     var s = newStringStream(input)
 
     var rows: ValueArray
 
     if not withHeaders:
-        open(x, s, "")
+        open(x, s, "", separator=withDelimiter)
         while readRow(x):
             var row: ValueArray
 
@@ -34,7 +34,7 @@ proc parseCsvInput*(input: string, withHeaders: bool = false): Value =
 
             rows.add(newBlock(row))
     else:
-        open(x, s, "")
+        open(x, s, "", separator=withDelimiter)
         readHeaderRow(x)
         while readRow(x):
             var row: ValueDict = initOrderedTable[string,Value]()

--- a/src/library/Files.nim
+++ b/src/library/Files.nim
@@ -302,6 +302,7 @@ proc defineSymbols*() =
                         "lines"         : ({Logical},"read file lines into block"),
                         "json"          : ({Logical},"read Json into value"),
                         "csv"           : ({Logical},"read CSV file into a block of rows"),
+                        "delimiter"     : ({Char},   "read CSV file with a specific delimiter"),
                         "withHeaders"   : ({Logical},"read CSV headers"),
                         "html"          : ({Logical},"read HTML into node dictionary"),
                         "xml"           : ({Logical},"read XML into node dictionary"),
@@ -316,6 +317,7 @@ proc defineSymbols*() =
                         "lines"         : ({Logical},"read file lines into block"),
                         "json"          : ({Logical},"read Json into value"),
                         "csv"           : ({Logical},"read CSV file into a block of rows"),
+                        "delimiter"     : ({Char},   "read CSV file with a specific delimiter"),
                         "withHeaders"   : ({Logical},"read CSV headers"),
                         "bytecode"      : ({Logical},"read file as Arturo bytecode"),
                         "binary"        : ({Logical},"read as binary"),
@@ -356,7 +358,11 @@ proc defineSymbols*() =
                     elif (hadAttr("json")):
                         push(valueFromJson(src))
                     elif (hadAttr("csv")):
-                        push(parseCsvInput(src, withHeaders=(hadAttr("withHeaders"))))
+                        if checkAttr("delimiter"):
+                            let delimiter = aDelimiter.c.char()
+                            push(parseCsvInput(src, withHeaders=hadAttr("withHeaders"), withDelimiter=delimiter))
+                        else:
+                            push(parseCsvInput(src, (hadAttr("withHeaders"))))
                     elif (hadAttr("bytecode")):
                         let bcode = readBytecode(x.s)
                         let parsed = doParse(bcode[0], isFile=false).a[0]

--- a/tests/unittests/lib.files.art
+++ b/tests/unittests/lib.files.art
@@ -373,6 +373,27 @@ do
 
 ]
 
+topic "read.csv.delimiter"
+do
+[
+
+    dir: createTestFolder "read-csv-delimiter"
+
+    write ~"|dir|/test.csv" {
+        language; version; platform
+        Arturo; 0.9.83; win10
+        Python; 3.9; gnu/linux
+        Ruby; 3.2.1; macOS
+    }
+
+    ensure -> exists? ~"|dir|/test.csv"
+
+    ; ---------//---------//---------//
+
+    inspect read.csv.delimiter: `;` ~"|dir|/test.csv"
+
+]
+
 topic "read.csv.withHeaders"
 do [
 

--- a/tests/unittests/lib.files.res
+++ b/tests/unittests/lib.files.res
@@ -100,6 +100,31 @@ This is a multiline File.
         ]
 ]
 
+>> read.csv.delimiter
+
+[ :block
+        [ :block
+                language :string
+                 version :string
+                 platform :string
+        ]
+        [ :block
+                Arturo :string
+                 0.9.83 :string
+                 win10 :string
+        ]
+        [ :block
+                Python :string
+                 3.9 :string
+                 gnu/linux :string
+        ]
+        [ :block
+                Ruby :string
+                 3.2.1 :string
+                 macOS :string
+        ]
+]
+
 >> read.csv.withHeaders
 
 [ :block


### PR DESCRIPTION
Fixes #1016

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Update/Add unit-tests
- [x] This change requires a documentation update