### PR TITLE
WIP - [Files/exists?] add new `.symlink` option

### DIFF
--- a/src/library/Files.nim
+++ b/src/library/Files.nim
@@ -123,7 +123,8 @@ proc defineSymbols*() =
                 "file"  : {String}
             },
             attrs       = {
-                "directory" : ({Logical},"check for directory")
+                "directory" : ({Logical},"check for directory"),
+                "symlink"   : ({Logical},"check for symlink")
             },
             returns     = {Logical},
             example     = """
@@ -136,6 +137,8 @@ proc defineSymbols*() =
 
                 if (hadAttr("directory")): 
                     push(newLogical(dirExists(x.s)))
+                elif (hadAttr("symlink")): 
+                    push(newLogical(symlinkExists(x.s)))
                 else: 
                     push(newLogical(fileExists(x.s)))
 

--- a/tests/unittests/lib.files.art
+++ b/tests/unittests/lib.files.art
@@ -664,14 +664,25 @@ do [
 
 ; ; -- Test: symlink
 
-;; How can I properly test it?
-; topic "rename.directory"
-; do [
-;
-;     ; cleaning
-;     execute "rm temp/* --recursive"
-;
-; ]
+topic "symlink & exists.symlink"
+do [
+
+    dir: createTestFolder "symlink"
+    
+    write ~"|dir|/a.md" « # Hello, world
+    write ~"|dir|/b.md" «
+    
+    ; For windows, you need have administrator privileges to create symlinks
+    if ("windows" <> sys\os) [
+        symlink.hard ~"|dir|/a.md" ~"|dir|/b.md"
+    
+        write ~"|dir|/a.md" « # Hello, Arturo
+        
+        ensure -> exists?.symlink ~"|dir|/a.md"
+        ensure -> exists?.symlink ~"|dir|/b.md"
+    ]
+
+]
 
 ; -- Test: timestamp
 

--- a/tests/unittests/lib.files.art
+++ b/tests/unittests/lib.files.art
@@ -662,20 +662,17 @@ do [
 
 ]
 
-; ; -- Test: symlink
+; -- Test: symlink
 
 topic "symlink & exists.symlink"
 do [
 
     dir: createTestFolder "symlink"
     
-    write ~"|dir|/a.md" « # Hello, world
-    
     ; For windows, you need have administrator privileges to create symlinks
     if ("windows" <> sys\os) [
-        symlink.hard "README.md" "/home/README.md"
+        symlink.hard "README.md" ~"|dir|/README.md"
         ensure -> exists?.symlink ~"|dir|/README.md"
-        ensure -> exists?.symlink "/home/README.md"
     ]
 
 ]

--- a/tests/unittests/lib.files.art
+++ b/tests/unittests/lib.files.art
@@ -670,16 +670,12 @@ do [
     dir: createTestFolder "symlink"
     
     write ~"|dir|/a.md" « # Hello, world
-    write ~"|dir|/b.md" «
     
     ; For windows, you need have administrator privileges to create symlinks
     if ("windows" <> sys\os) [
-        symlink.hard ~"|dir|/a.md" ~"|dir|/b.md"
-    
-        write ~"|dir|/a.md" « # Hello, Arturo
-        
-        ensure -> exists?.symlink ~"|dir|/a.md"
-        ensure -> exists?.symlink ~"|dir|/b.md"
+        symlink.hard "README.md" "/home/README.md"
+        ensure -> exists?.symlink ~"|dir|/README.md"
+        ensure -> exists?.symlink "/home/README.md"
     ]
 
 ]

--- a/tests/unittests/lib.files.res
+++ b/tests/unittests/lib.files.res
@@ -312,6 +312,9 @@ file:  Hello, world!
 
 directory renamed
 
+>> symlink & exists.symlink
+
+
 >> timestamp
 
 all fields are filled: [created accessed modified]


### PR DESCRIPTION
## Note
Symlinks creation on windows just works for users with Administrator Privileges.
So, I jumped these tests for windows, and added just `ensure`s for Unix.

Fixes #1009

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Update/Add unit-tests
- [x] This change requires a documentation update