### PR TITLE
[Collections] add `.deep` attribute for `contains?` & `in?`

### DIFF
--- a/src/helpers/arrays.nim
+++ b/src/helpers/arrays.nim
@@ -211,3 +211,15 @@ proc prependInPlace*(s: var Value, t: Value) {.inline,enforceNoRaises.} =
     for i in t.a:
         s.a.insert(i, cnt)
         cnt += 1
+
+
+proc inNestedBlock*(container: ValueArray, target: Value): bool =
+    for element in container:
+        if element == target:
+            return true
+        if element.kind == Block:
+            if element.a.inNestedBlock(target):
+                return true
+        
+    return false
+        

--- a/src/helpers/dictionaries.nim
+++ b/src/helpers/dictionaries.nim
@@ -22,3 +22,11 @@ proc flattenedDictionary*(vd: ValueDict): ValueArray =
     for k,v in vd.pairs:
         result.add(newString(k))
         result.add(v)
+        
+        
+proc getValuesinDeep*(dict: ValueDict): ValueArray =
+    for key, value in dict.pairs:
+        if value.kind == Dictionary:
+            result.add getValuesinDeep(value.d)
+        else:
+            result.add value

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -313,8 +313,8 @@ proc defineSymbols*() =
                         push(newLogical(y in x.rng))
                     of Dictionary:
                         if hadAttr("deep"):
-                            let values = toSeq(flattenedDictionary(x.d))
-                            push newLogical(values.inNestedBlock(y))
+                            let values: ValueArray = x.d.getValuesinDeep()
+                            push newLogical(y in values)
                         else:
                             let values = toSeq(x.d.values)
                             push(newLogical(y in values))

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -679,7 +679,8 @@ proc defineSymbols*() =
             "collection": {String, Block, Range, Dictionary}
         },
         attrs       = {
-            "at"    : ({Integer}, "check at given location within collection")
+            "at"    : ({Integer}, "check at given location within collection"),
+            "deep"    : ({Logical}, "searches recursively in deep for a value.")
         },
         returns     = {Logical},
         example     = """
@@ -740,12 +741,19 @@ proc defineSymbols*() =
                         else:
                             push(newLogical(x.s in y.s))
                     of Block:
-                        push(newLogical(x in y.a))
+                        if hadAttr("deep"):
+                            push newLogical(y.a.inNestedBlock(x))
+                        else:
+                            push(newLogical(x in y.a))
                     of Range:
                         push(newLogical(x in y.rng))
                     of Dictionary:
-                        let values = toSeq(y.d.values)
-                        push(newLogical(x in values))
+                        if hadAttr("deep"):
+                            let values: ValueArray = y.d.getValuesinDeep()
+                            push newLogical(x in values)
+                        else:
+                            let values = toSeq(y.d.values)
+                            push(newLogical(x in values))
                     else:
                         discard
 

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -224,10 +224,6 @@ proc defineSymbols*() =
                 push(newBlock(getCombinations(x.a, sz, doRepeat).map((
                         z)=>newBlock(z))))
 
-    # TODO(Collections/contains?) add new `.deep` option?
-    #  this would allow us to check whether a nested block contains a specific value
-    #  e.g. `contains?.deep [[1 2 3] [4 5 6]] 2` would return *true*
-    #  labels: library, enhancement, open discussion
 
     # TODO(Collections/contains?) add new `.key` option?
     #  this would allow us to check whether the given dictionary contains a specific key

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -274,6 +274,17 @@ proc defineSymbols*() =
 
             print contains?.at:1 ["one" "two" "three"] "two"
             ; true
+            ..........
+            print contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 6
+            ; true
+            ..........
+            user: #[ 
+                name: "John" surname: "Doe"
+                mom: #[ name: "Jane" surname: "Doe" ]
+            ]
+            
+            print contains?.deep user "Jane"
+            ; true
         """:
             #=======================================================
             if checkAttr("at"):

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -242,7 +242,8 @@ proc defineSymbols*() =
             "value"     : {Any}
         },
         attrs       = {
-            "at"    : ({Integer}, "check at given location within collection")
+            "at"    : ({Integer}, "check at given location within collection"),
+            "deep"    : ({Logical}, "searches recursively in deep for a value.")
         },
         returns     = {Logical},
         example     = """
@@ -303,12 +304,18 @@ proc defineSymbols*() =
                         else:
                             push(newLogical(y.s in x.s))
                     of Block:
-                        push(newLogical(y in x.a))
+                        if hadAttr("deep"):
+                            push newLogical(x.a.inNestedBlock(y))
+                        else:
+                            push(newLogical(y in x.a))
                     of Range:
                         push(newLogical(y in x.rng))
                     of Dictionary:
                         let values = toSeq(x.d.values)
-                        push(newLogical(y in values))
+                        if hadAttr("deep"):
+                            push newLogical(values.inNestedBlock(y))
+                        else:
+                            push(newLogical(y in values))
                     else:
                         discard
 

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -710,6 +710,17 @@ proc defineSymbols*() =
 
             print in?.at:1 "two" ["one" "two" "three"]
             ; true
+            ..........
+            print in?.deep 6 [1 2 4 [3 4 [5 6] 7] 8 [9 10]]
+            ; true
+            ..........
+            user: #[ 
+                name: "John" surname: "Doe"
+                mom: #[ name: "Jane" surname: "Doe" ]
+            ]
+            
+            print in?.deep "Jane" user
+            ; true
         """:
             #=======================================================
             if checkAttr("at"):

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -31,6 +31,7 @@ import algorithm, os, random, sequtils
 import strutils, sugar, unicode
 
 import helpers/arrays
+import helpers/dictionaries
 import helpers/combinatorics
 import helpers/ranges
 when not defined(WEB):
@@ -311,10 +312,11 @@ proc defineSymbols*() =
                     of Range:
                         push(newLogical(y in x.rng))
                     of Dictionary:
-                        let values = toSeq(x.d.values)
                         if hadAttr("deep"):
+                            let values = toSeq(flattenedDictionary(x.d))
                             push newLogical(values.inNestedBlock(y))
                         else:
+                            let values = toSeq(x.d.values)
                             push(newLogical(y in values))
                     else:
                         discard

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -662,9 +662,6 @@ proc defineSymbols*() =
                     push(GetKey(x.e, y.s))
                 else: discard
 
-    # TODO(Collections/in?) add new `.deep` option?
-    #  same as with `contains?`
-    #  labels: library, enhancement, open discussion
 
     # TODO(Collections/in?) add new `.key` option?
     #  same as with `contains?`

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -836,6 +836,47 @@ do [
 
 ]
 
+topic "in?.deep - with :block"
+do [
+ 
+    ensure -> in?.deep 6 [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 
+    ensure -> in?.deep 5 [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 
+    ensure -> in?.deep 8 [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 
+    ensure -> in?.deep 9 [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 
+    ensure -> in?.deep 3 [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 
+    ensure -> in?.deep 4 [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 
+    ensure -> in?.deep 2 [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 
+    ensure -> in?.deep 1 [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 
+    ensure -> in?.deep 10 [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 
+    passed
+    ensure -> not? in?.deep 0 [1 2 4 [3 4 [5 6] 7] 8 [9 10]]
+    ensure -> not? in?.deep 11 [1 2 4 [3 4 [5 6] 7] 8 [9 10]]
+    passed
+    
+]
+
+topic "in?.deep - with :dictionary"
+do [
+    
+    user: #[ 
+        name: "John" 
+        surname: "Doe"
+        mom: #[
+            name: "Jane"
+            surname: "Doe"
+        ]
+    ]
+    
+    ensure -> in?.deep "John" user
+    ensure -> in?.deep "Jane" user
+    ensure -> in?.deep "Doe" user
+    passed
+    ensure -> not? in?.deep "Joshep" user
+    ensure -> not? in?.deep "Juan" user
+    passed
+    
+]
+
 
 topic "index - :string"
 do [

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -431,6 +431,7 @@ do [
     ensure -> contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 4
     ensure -> contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 2
     ensure -> contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 1
+    passed
     ensure -> not? contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 11
     ensure -> not? contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 0
     passed
@@ -452,6 +453,7 @@ do [
     ensure -> contains?.deep "John"
     ensure -> contains?.deep "Jane"
     ensure -> contains?.deep "Doe"
+    passed
     ensure -> not? contains?.deep "Joshep"
     ensure -> not? contains?.deep "Juan"
     passed

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -419,6 +419,45 @@ do [
 
 ]
 
+topic "contains?.deep - with :block"
+do [
+ 
+    ensure -> contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 6
+    ensure -> contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 5
+    ensure -> contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 8
+    ensure -> contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 9
+    ensure -> contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 10
+    ensure -> contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 3
+    ensure -> contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 4
+    ensure -> contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 2
+    ensure -> contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 1
+    ensure -> not? contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 11
+    ensure -> not? contains?.deep [1 2 4 [3 4 [5 6] 7] 8 [9 10]] 0
+    passed
+    
+]
+
+topic "contains?.deep - with :dictionary"
+do [
+    
+    user: #[ 
+        name: "John" 
+        surname: "Doe"
+        mom: #[
+            name: "Jane"
+            surname: "Doe"
+        ]
+    ]
+    
+    ensure -> contains?.deep "John"
+    ensure -> contains?.deep "Jane"
+    ensure -> contains?.deep "Doe"
+    ensure -> not? contains?.deep "Joshep"
+    ensure -> not? contains?.deep "Juan"
+    passed
+    
+]
+
 ; couple don't support literals yet
 topic "couple"
 do [

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -450,12 +450,12 @@ do [
         ]
     ]
     
-    ensure -> contains?.deep "John"
-    ensure -> contains?.deep "Jane"
-    ensure -> contains?.deep "Doe"
+    ensure -> contains?.deep user "John"
+    ensure -> contains?.deep user "Jane"
+    ensure -> contains?.deep user "Doe"
     passed
-    ensure -> not? contains?.deep "Joshep"
-    ensure -> not? contains?.deep "Juan"
+    ensure -> not? contains?.deep user "Joshep"
+    ensure -> not? contains?.deep user "Juan"
     passed
     
 ]

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -292,6 +292,14 @@
 [+] passed!
 [+] passed!
 
+>> in?.deep - with :block
+[+] passed!
+[+] passed!
+
+>> in?.deep - with :dictionary
+[+] passed!
+[+] passed!
+
 >> index - :string
 [+] passed!
 [+] passed!

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -147,6 +147,14 @@
 [+] passed!
 [+] passed!
 
+>> contains?.deep - with :block
+[+] passed!
+[+] passed!
+
+>> contains?.deep - with :dictionary
+[+] passed!
+[+] passed!
+
 >> couple
 [+] passed!
 


### PR DESCRIPTION
# Description
`contains?.deep` and `in?.deep` should search recursively for some value in a container (`:block` or `:dictionary`) and return a `:logic`.

Fixes #958 #955 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Update unit-tests
- [x] This change requires a documentation update
- [x] Add usage