### PR TITLE
WIP - [Collections\split] fix `.every` for literal strings

### DIFF
--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -1951,8 +1951,8 @@ proc defineSymbols*() =
                         var ret: seq[string]
                         var length = InPlaced.s.len
                         var i = 0
-
-                        while i <= length:
+                        
+                        while i < length:
                             if i + aEvery.i <= length:
                                 ret.add(InPlaced.s[i..i+aEvery.i-1])
                                 i += aEvery.i

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -2349,9 +2349,9 @@ do [
     ensure -> ["A" "r" "t" "u" "r" "o"] = a
     passed
     
-    ; a: "Arturo", split.every: 3 'a
-    ; ensure -> ["Art" "uro"] = a
-    ; passed
+    a: "Arturo", split.every: 3 'a
+    ensure -> ["Art" "uro"] = a
+    passed
     
     ; Don't do anyting for :block type
     a: [[1 2 3] [4 5 6] [7 8]], split 'a

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -655,6 +655,7 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
 
 >> split - .words
 [+] passed!


### PR DESCRIPTION
# Description
This function was broken for literal strings when the length is divisible by `every` attribute
Fixes #1052

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Update unit-tests