### PR TITLE
[Collections\sort] fix `.ascii` for literals

### DIFF
--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -1787,18 +1787,23 @@ proc defineSymbols*() =
                                 proc (v1, v2: Value): int =
                                 cmp(v1.d[aBy.s], v2.d[aBy.s]),
                                         order = sortOrdering)
-                        else:
+                        else:               
+                            var sortAscii = (hadAttr("ascii"))
+                            
                             if checkAttr("as"):
                                 InPlaced.a.unisort(aAs.s, sensitive = hadAttr(
-                                        "sensitive"), order = sortOrdering)
+                                        "sensitive"), order = sortOrdering, 
+                                        ascii = sortAscii)
                             else:
                                 if (hadAttr("sensitive")):
                                     InPlaced.a.unisort("en", sensitive = true,
-                                            order = sortOrdering)
+                                            order = sortOrdering, 
+                                            ascii = sortAscii)
                                 else:
                                     if InPlaced.a[0].kind == String:
                                         InPlaced.a.unisort("en",
-                                                order = sortOrdering)
+                                                order = sortOrdering, 
+                                                ascii = sortAscii)
                                     else:
                                         InPlaced.a.sort(order = sortOrdering)
                 else:

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -2035,17 +2035,17 @@ do [
     ; .ascii
     
     
-    ; a: ["uno","dos","tres","Uno","perversión","ábaco","abismo", "aberración"]
-    ; sort.ascii 'a
-    ; ensure -> ["ábaco" "aberración" "abismo" "dos" "perversión" "tres" "uno" "Uno"]
-    ;     = a
-    ; passed
+    a: ["uno","dos","tres","Uno","perversión","ábaco","abismo", "aberración"]
+    sort.ascii 'a
+    ensure -> ["ábaco" "aberración" "abismo" "dos" "perversión" "tres" "uno" "Uno"]
+        = a
+    passed
     
-    ; a: ["uno","dos","tres","Uno","perversión","ábaco","abismo", "aberración"]
-    ; sort.descending.ascii 'a
-    ; ensure -> ["uno" "Uno" "tres" "perversión" "dos" "abismo" "aberración" "ábaco"]
-    ;    = a
-    ; passed
+    a: ["uno","dos","tres","Uno","perversión","ábaco","abismo", "aberración"]
+    sort.descending.ascii 'a
+    ensure -> ["uno" "Uno" "tres" "perversión" "dos" "abismo" "aberración" "ábaco"]
+       = a
+    passed
     
     
 ]

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -612,6 +612,8 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
+[+] passed!
 
 >> sort - .values
 [+] passed!


### PR DESCRIPTION
# Description
Fix `.ascii` option not working with literals.

Fixes part of #1051

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Update unit-tests