### PR TITLE
WIP - [Collections\get] fix string's slice

### DIFF
--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -641,7 +641,16 @@ proc defineSymbols*() =
                             else:
                                 push(getStoreKey(x.sto, $(y)))
                 of String:
-                    push(newChar(x.s.runeAtPos(y.i)))
+                    if likely(y.kind==Integer):
+                        push(newChar(x.s.runeAtPos(y.i)))
+                    else:
+                        let rLen = y.rng.len
+                        var res: seq[Rune] = newSeq[Rune](rLen)
+                        var i = 0
+                        for item in items(y.rng):
+                            res[i] = x.s.runeAtPos(item.i)
+                            i += 1
+                        push(newString($(res)))
                 of Date:
                     push(GetKey(x.e, y.s))
                 else: discard

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -586,6 +586,7 @@ proc defineSymbols*() =
             print get str 1               ; e
             z: 0
             print str\[z+1]               ; e
+            print str\[0..4]              ; Hello
         """:
             #=======================================================
             case x.kind:

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -582,6 +582,24 @@ do [
     ensure -> `r` = s\[i + 1]
     passed
     
+    ensure -> "Art"    = get s 0..2
+    ensure -> "Artur"  = get s 0..4
+    ensure -> "Arturo" = get s 0..5
+    ensure -> "orutrA" = get s 5..0
+    ensure -> "rutrA"  = get s 4..0
+    ensure -> "trA"    = get s 2..0
+    ensure -> "r"      = get s 1..1
+    passed
+    
+    ensure -> "Art" = s\[0..2]
+    ensure -> "Artur" = s\[0..4]
+    ensure -> "Arturo" = s\[0..5]
+    ensure -> "orutrA" = s\[5..0]
+    ensure -> "rutrA" = s\[4..0]
+    ensure -> "trA" = s\[2..0]
+    ensure -> "r" = s\[1..1]
+    passed
+    
 ]
 
 topic "get - :date"

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -204,6 +204,8 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
+[+] passed!
 
 >> get - :date
 [+] passed!


### PR DESCRIPTION
# Description
The syntax `string\[1..2]` was not working, it's the same as `get string 1..2`.

Fixes #1048

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Update unit-tests
- [x] Add usage
- [x] This change requires a documentation update