### PR TITLE
[System/sys] add info about endianess

### DIFF
--- a/src/library/System.nim
+++ b/src/library/System.nim
@@ -377,8 +377,8 @@ proc defineSymbols*() =
             ;	] 
             ;	binary     :	/Users/drkameleon/OpenSource/arturo-lang/arturo/bin/arturo :string
             ;	cpu        :        [ :dictionary
-            ;           type    :                amd64 :string
-            ;           endian  :                little :string
+            ;           arch    :                amd64 :literal
+            ;           endian  :                little :literal
             ;   ]
             ; 	os         :	macosx :string
             ;  	release    :	full :literal

--- a/src/library/System.nim
+++ b/src/library/System.nim
@@ -376,7 +376,10 @@ proc defineSymbols*() =
             ;		pcre    :		8.45.0 :version
             ;	] 
             ;	binary     :	/Users/drkameleon/OpenSource/arturo-lang/arturo/bin/arturo :string
-            ;	cpu        :	amd64 :string
+            ;	cpu        :        [ :dictionary
+            ;           type    :                amd64 :string
+            ;           endian  :                little :string
+            ;   ]
             ; 	os         :	macosx :string
             ;  	release    :	full :literal
             ;]

--- a/src/vm/env.nim
+++ b/src/vm/env.nim
@@ -113,7 +113,7 @@ proc getSystemInfo*(): ValueDict =
                     newLiteral("full")
         }.toOrderedTable
         
-        result["cpu"].d["type"] = newString(hostCPU)
+        result["cpu"].d["arch"] = newString(hostCPU)
         result["cpu"].d["endian"] = 
             if cpuEndian == Endianness.littleEndian:
                 newLiteral("little")

--- a/src/vm/env.nim
+++ b/src/vm/env.nim
@@ -113,7 +113,7 @@ proc getSystemInfo*(): ValueDict =
                     newLiteral("full")
         }.toOrderedTable
         
-        result["cpu"].d["arch"] = newString(hostCPU)
+        result["cpu"].d["arch"] = newLiteral(hostCPU)
         result["cpu"].d["endian"] = 
             if cpuEndian == Endianness.littleEndian:
                 newLiteral("little")

--- a/src/vm/env.nim
+++ b/src/vm/env.nim
@@ -116,9 +116,9 @@ proc getSystemInfo*(): ValueDict =
         result["cpu"].d["type"] = newString(hostCPU)
         result["cpu"].d["endian"] = 
             if cpuEndian == Endianness.littleEndian:
-                newString("little")
+                newLiteral("little")
             else:
-                newString("big")
+                newLiteral("big")
 
         when not defined(NOGMP):
             result["deps"].d["gmp"] = newVersion($(gmpVersion))

--- a/src/vm/env.nim
+++ b/src/vm/env.nim
@@ -23,7 +23,7 @@ when not defined(NOSQLITE):
 
 import pcre
 
-import os, strutils, tables, times
+import os, strutils, tables, times, system
 
 import helpers/terminal
 
@@ -104,7 +104,7 @@ proc getSystemInfo*(): ValueDict =
                     newString("arturo.js")
                 else:
                     newString(getAppFilename()),
-            "cpu"       : newString(hostCPU),
+            "cpu"       : newDictionary(),
             "os"        : newString(hostOS),
             "release"   : 
                 when defined(MINI):
@@ -112,6 +112,13 @@ proc getSystemInfo*(): ValueDict =
                 else:
                     newLiteral("full")
         }.toOrderedTable
+        
+        result["cpu"].d["type"] = newString(hostCPU)
+        result["cpu"].d["endian"] = 
+            if cpuEndian == Endianness.littleEndian:
+                newString("little")
+            else:
+                newString("big")
 
         when not defined(NOGMP):
             result["deps"].d["gmp"] = newVersion($(gmpVersion))

--- a/tests/unittests/lib.system.art
+++ b/tests/unittests/lib.system.art
@@ -1,2 +1,31 @@
 topic: $[topic :string] -> print ~"\n>> |topic|"
 passed: $[] -> print "[+] passed!"
+
+topic "sys"
+do [
+            
+    ensure -> dictionary? sys
+    passed
+    
+    ensure -> string? sys\author
+    ensure -> string? sys\copyright
+    passed
+    
+    ensure -> version? sys\version
+    ensure -> integer? sys\build
+    ensure -> date? sys\buildDate
+    ensure -> dictionary? sys\deps
+    ensure -> string? sys\binary
+    ensure -> literal? sys\release
+    passed
+    
+    ensure -> dictionary? sys\cpu
+    ensure -> string? sys\cpu\type
+    ensure -> and? string? sys\cpu\endian
+              or? 
+                equal? sys\cpu\endian "little"
+                equal? sys\cpu\endian "big"
+    ensure -> string? sys\os
+    passed
+    
+]

--- a/tests/unittests/lib.system.art
+++ b/tests/unittests/lib.system.art
@@ -20,7 +20,7 @@ do [
     passed
     
     ensure -> dictionary? sys\cpu
-    ensure -> string? sys\cpu\arch
+    ensure -> literal? sys\cpu\arch
     ensure -> and? literal? sys\cpu\endian
               or? 
                 equal? sys\cpu\endian 'little

--- a/tests/unittests/lib.system.art
+++ b/tests/unittests/lib.system.art
@@ -1,0 +1,2 @@
+topic: $[topic :string] -> print ~"\n>> |topic|"
+passed: $[] -> print "[+] passed!"

--- a/tests/unittests/lib.system.art
+++ b/tests/unittests/lib.system.art
@@ -21,10 +21,10 @@ do [
     
     ensure -> dictionary? sys\cpu
     ensure -> string? sys\cpu\type
-    ensure -> and? string? sys\cpu\endian
+    ensure -> and? literal? sys\cpu\endian
               or? 
-                equal? sys\cpu\endian "little"
-                equal? sys\cpu\endian "big"
+                equal? sys\cpu\endian 'little
+                equal? sys\cpu\endian 'big
     ensure -> string? sys\os
     passed
     

--- a/tests/unittests/lib.system.art
+++ b/tests/unittests/lib.system.art
@@ -20,7 +20,7 @@ do [
     passed
     
     ensure -> dictionary? sys\cpu
-    ensure -> string? sys\cpu\type
+    ensure -> string? sys\cpu\arch
     ensure -> and? literal? sys\cpu\endian
               or? 
                 equal? sys\cpu\endian 'little

--- a/tests/unittests/lib.system.res
+++ b/tests/unittests/lib.system.res
@@ -1,0 +1,6 @@
+
+>> sys
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!


### PR DESCRIPTION
# Description

> or, perhaps even better, make our existing cpu field a dictionary with two fields:

I followed this approach, making `cpu` a `:dictionary` with two fields: `type` and `endian`.

Fixes #1036

--- 

## Updates

`cpu` is now a dictionary with two literals: `arch` (the old `type`) and `endian`.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update usage
- [x] This change requires a documentation update 