### PR TITLE
Sanitize arch names in binaries & releases + workflows cleanup

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -31,7 +31,7 @@ jobs:
         version:
           - mini
         arch:
-          - x86_64
+          - amd64
     steps:
       - name: "Checkout"
         uses: actions/checkout@main

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
           - safe
         arch:
           - x86
-          - x86_64
+          - amd64
           - arm
           - arm64
         exclude:
@@ -114,7 +114,7 @@ jobs:
           path: bin/arturo
 
       - name: Run unit tests
-        if: matrix.arch == 'x86_64' && (matrix.version == 'full' || matrix.version == 'mini')
+        if: matrix.arch == 'amd64' && (matrix.version == 'full' || matrix.version == 'mini')
         run: |
           echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
           arturo tools/tester.art

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -33,7 +33,7 @@ jobs:
           - mini
           - full
         arch:
-          - x86_64
+          - amd64
     steps:
       - name: "Checkout"
         uses: actions/checkout@main

--- a/.github/workflows/netbsd.yml
+++ b/.github/workflows/netbsd.yml
@@ -31,7 +31,7 @@ jobs:
         version:
           - mini
         arch:
-          - x86_64
+          - amd64
     steps:
       - name: "Checkout"
         uses: actions/checkout@main

--- a/.github/workflows/openbsd.yml
+++ b/.github/workflows/openbsd.yml
@@ -31,7 +31,7 @@ jobs:
         version:
           - mini
         arch:
-          - x86_64
+          - amd64
     steps:
       - name: "Checkout"
         uses: actions/checkout@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           - full
         arch:
           - x86
-          - x86_64
+          - amd64
           - arm
           - arm64
         exclude:
@@ -195,7 +195,7 @@ jobs:
         version:
           - mini
         arch:
-          - x86_64
+          - amd64
 
     steps:
       - name: "Cancel similar actions in progress"
@@ -246,7 +246,7 @@ jobs:
         version:
           - mini
         arch:
-          - x86_64
+          - amd64
 
     steps:
       - name: "Cancel similar actions in progress"
@@ -297,7 +297,7 @@ jobs:
         version:
           - mini
         arch:
-          - x86_64
+          - amd64
 
     steps:
       - name: "Cancel similar actions in progress"
@@ -349,7 +349,7 @@ jobs:
           - mini
           - full
         arch:
-          - x86_64
+          - amd64
 
     steps:
       - name: "Cancel similar actions in progress"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
           - mini
           - full
         arch:
-          - x86_64
+          - amd64
     steps:
       - name: "Checkout"
         uses: actions/checkout@main

--- a/build.nims
+++ b/build.nims
@@ -81,7 +81,7 @@ let
         "vcc"               : "",
         "web"               : "--verbosity:3 -d:WEB",
         "x86"               : "--cpu:i386 " & (when defined(gcc): "--passC:'-m32' --passL:'-m32'" else: ""),  
-        "x86_64"            : ""
+        "amd64"             : ""
     }.toTable
 
 #=======================================

--- a/docs/website/theme/index.html
+++ b/docs/website/theme/index.html
@@ -171,17 +171,17 @@
                                 </svg>
                             </td>
                             <td><b>Linux</b></td>
-                            <td class="is-hidden-touch has-text-centered">x86_64</td>
+                            <td class="is-hidden-touch has-text-centered">amd64</td>
                             <td class="is-hidden-touch has-text-centered">
-                                <span id="linux-x86_64-full-size" class="full-version">1.84 MB</span>
-                                <span id="linux-x86_64-mini-size" class="mini-version is-hidden">1.28 MB</span>
+                                <span id="linux-amd64-full-size" class="full-version">1.84 MB</span>
+                                <span id="linux-amd64-mini-size" class="mini-version is-hidden">1.28 MB</span>
                             </td>
                             <td>
-                                <span id="linux-x86_64-full-download" class="full-version">
-                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-full-x86_64-linux.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
+                                <span id="linux-amd64-full-download" class="full-version">
+                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-full-amd64-linux.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
                                 </span>
-                                <span id="linux-x86_64-mini-download" class="mini-version is-hidden">
-                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-mini-x86_64-linux.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
+                                <span id="linux-amd64-mini-download" class="mini-version is-hidden">
+                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-mini-amd64-linux.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
                                 </span>
                             </td>
                         </tr>
@@ -234,17 +234,17 @@
                                 </svg>
                             </td>
                             <td><b>macOS</b></td>
-                            <td class="is-hidden-touch has-text-centered">x86_64</td>
+                            <td class="is-hidden-touch has-text-centered">amd64</td>
                             <td class="is-hidden-touch has-text-centered">
-                                <span id="macos-x86_64-full-size" class="full-version">1.81 MB</span>
-                                <span id="macos-x86_64-mini-size" class="mini-version is-hidden">1.42 MB</span>
+                                <span id="macos-amd64-full-size" class="full-version">1.81 MB</span>
+                                <span id="macos-amd64-mini-size" class="mini-version is-hidden">1.42 MB</span>
                             </td>
                             <td>
-                                <span id="macos-x86_64-full-download" class="full-version">
-                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-full-x86_64-macos.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
+                                <span id="macos-amd64-full-download" class="full-version">
+                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-full-amd64-macos.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
                                 </span>
-                                <span id="macos-x86_64-mini-download" class="mini-version is-hidden">
-                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-mini-x86_64-macos.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
+                                <span id="macos-amd64-mini-download" class="mini-version is-hidden">
+                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-mini-amd64-macos.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
                                 </span>
                             </td>
                         </tr>
@@ -276,17 +276,17 @@
                                 </svg>
                             </td>
                             <td><b>Windows</b></td>
-                            <td class="is-hidden-touch has-text-centered">x86_64</td>
+                            <td class="is-hidden-touch has-text-centered">amd64</td>
                             <td class="is-hidden-touch has-text-centered">
-                                <span id="windows-x86_64-full-size" class="full-version">5.25 MB</span>
-                                <span id="windows-x86_64-mini-size" class="mini-version is-hidden">2.81 MB</span>
+                                <span id="windows-amd64-full-size" class="full-version">5.25 MB</span>
+                                <span id="windows-amd64-mini-size" class="mini-version is-hidden">2.81 MB</span>
                             </td>
                             <td>
-                                <span id="windows-x86_64-full-download" class="full-version">
-                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-full-x86_64-windows.zip"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
+                                <span id="windows-amd64-full-download" class="full-version">
+                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-full-amd64-windows.zip"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
                                 </span>
-                                <span id="windows-x86_64-mini-download" class="mini-version is-hidden">
-                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-mini-x86_64-windows.zip"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
+                                <span id="windows-amd64-mini-download" class="mini-version is-hidden">
+                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-mini-amd64-windows.zip"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
                                 </span>
                             </td>
                         </tr>
@@ -297,17 +297,17 @@
                                 </svg>
                             </td>
                             <td><b>Windows / MSYS2</b></td>
-                            <td class="is-hidden-touch has-text-centered">x86_64</td>
+                            <td class="is-hidden-touch has-text-centered">amd64</td>
                             <td class="is-hidden-touch has-text-centered">
-                                <span id="windows-x86_64-full-size" class="full-version">5.42 MB</span>
-                                <span id="windows-x86_64-mini-size" class="mini-version is-hidden">2.90 MB</span>
+                                <span id="windows-amd64-full-size" class="full-version">5.42 MB</span>
+                                <span id="windows-amd64-mini-size" class="mini-version is-hidden">2.90 MB</span>
                             </td>
                             <td>
-                                <span id="windows-x86_64-full-download" class="full-version">
-                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-full-x86_64-windows-msys2.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
+                                <span id="windows-amd64-full-download" class="full-version">
+                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-full-amd64-windows-msys2.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
                                 </span>
-                                <span id="windows-x86_64-mini-download" class="mini-version is-hidden">
-                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-mini-x86_64-windows-msys2.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
+                                <span id="windows-amd64-mini-download" class="mini-version is-hidden">
+                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-mini-amd64-windows-msys2.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
                                 </span>
                             </td>
                         </tr>
@@ -318,17 +318,17 @@
                                 </svg>
                             </td>
                             <td><b>FreeBSD</b><sup class="is-hidden-desktop">*</sup></td>
-                            <td class="is-hidden-touch has-text-centered">x86_64</td>
+                            <td class="is-hidden-touch has-text-centered">amd64</td>
                             <td class="is-hidden-touch has-text-centered">
-                                <span id="freebsd-x86_64-full-size" class="full-version">--</span>
-                                <span id="freebsd-x86_64-mini-size" class="mini-version is-hidden">1.32 MB</span>
+                                <span id="freebsd-amd64-full-size" class="full-version">--</span>
+                                <span id="freebsd-amd64-mini-size" class="mini-version is-hidden">1.32 MB</span>
                             </td>
                             <td>
-                                <span id="freebsd-x86_64-full-download" class="full-version">
+                                <span id="freebsd-amd64-full-download" class="full-version">
                                     <i><small>*MINI build only</small></i>
                                 </span>
-                                <span id="freebsd-x86_64-mini-download" class="mini-version is-hidden">
-                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-mini-x86_64-freebsd.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
+                                <span id="freebsd-amd64-mini-download" class="mini-version is-hidden">
+                                    <a href="https://github.com/arturo-lang/arturo/releases/download/v0.9.83/arturo-0.9.83-mini-amd64-freebsd.tar.gz"><i class="far fa-arrow-alt-circle-down" aria-hidden="true"></i>&nbsp;&nbsp;Download</a>
                                 </span>
                             </td>
                         </tr>

--- a/src/vm/env.nim
+++ b/src/vm/env.nim
@@ -117,7 +117,7 @@ proc getSystemInfo*(): ValueDict =
                     newLiteral("full")
         }.toOrderedTable
         
-        result["cpu"].d["arch"] = newLiteral(hostCPU)
+        result["cpu"].d["arch"] = newLiteral(hostCPU.replace("i386","x86"))
         result["cpu"].d["endian"] = 
             if cpuEndian == Endianness.littleEndian:
                 newLiteral("little")


### PR DESCRIPTION
# Description

What this PR does:

- Roughly speaking, whenever we had `x86_64` for 64-bit builds, we'll now have `amd64` (same for `sys\cpu\arch` and the binary names)
- If running on a 32-bit system, instead of Nim's Linux-ish `i386`, `sys\cpu\arch` will show `x86` (same as our binary releases)
- Add OpenBSD & NetBSD to the list of supported OS'es (in terms of builds & releases)

Fixes #1035 

## Type of change

- [x] Code cleanup
