### PR TITLE
[Core/ensure] add option for custom message

### DIFF
--- a/src/library/Core.nim
+++ b/src/library/Core.nim
@@ -412,10 +412,7 @@ proc defineSymbols*() =
             if isFalse(y): 
                 execUnscoped(x)
             
-    # TODO(Core/ensure) add option for custom message
-    #  so that when `ensure` fails, the message can be customized
-    #  use case: https://rosettacode.org/wiki/Assertions_in_design_by_contract
-    #  labels: library, enhancement
+            
     builtin "ensure",
         alias       = unaliased, 
         op          = opNop,

--- a/src/library/Core.nim
+++ b/src/library/Core.nim
@@ -434,6 +434,10 @@ proc defineSymbols*() =
             ensure [num > 0]
 
             print "good, the number is positive indeed. let's continue..."
+            ..........
+            ensure.message: "Wrong calc" ->  0 = 1 + 1
+            ; >> Assertion | "Wrong calc": [0 = 1 + 1]
+            ;        error |
         """:
             #=======================================================
             

--- a/src/library/Core.nim
+++ b/src/library/Core.nim
@@ -422,7 +422,7 @@ proc defineSymbols*() =
             "condition"     : {Block}
         },
         attrs       = {
-            "message"   : ({String},"prints a custom message when ensure fails")
+            "that"   : ({String},"prints a custom message when ensure fails")
         },
         returns     = {Nothing},
         example     = """
@@ -438,10 +438,10 @@ proc defineSymbols*() =
         """:
             #=======================================================
             
-            if checkAttr("message"):
+            if checkAttr("that"):
                 execUnscoped(x)
                 if isFalse(pop()):
-                    AssertionError_AssertionFailed(x.codify(), aMessage.s)
+                    AssertionError_AssertionFailed(x.codify(), aThat.s)
             else:
                 execUnscoped(x)
                 if isFalse(pop()):

--- a/src/library/Core.nim
+++ b/src/library/Core.nim
@@ -424,7 +424,9 @@ proc defineSymbols*() =
         args        = {
             "condition"     : {Block}
         },
-        attrs       = NoAttrs,
+        attrs       = {
+            "message"   : ({String},"prints a custom message when ensure fails")
+        },
         returns     = {Nothing},
         example     = """
             num: input "give me a positive number"
@@ -434,9 +436,15 @@ proc defineSymbols*() =
             print "good, the number is positive indeed. let's continue..."
         """:
             #=======================================================
-            execUnscoped(x)
-            if isFalse(pop()):
-                AssertionError_AssertionFailed(x.codify())
+            
+            if checkAttr("message"):
+                execUnscoped(x)
+                if isFalse(pop()):
+                    AssertionError_AssertionFailed(x.codify(), aMessage.s)
+            else:
+                execUnscoped(x)
+                if isFalse(pop()):
+                    AssertionError_AssertionFailed(x.codify())
 
     builtin "if",
         alias       = unaliased, 

--- a/src/vm/errors.nim
+++ b/src/vm/errors.nim
@@ -221,7 +221,8 @@ proc AssertionError_AssertionFailed*(context: string) =
           
 proc AssertionError_AssertionFailed*(context: string, message: string) =
     panic AssertionError, 
-          "\"" & message & "\": " & context
+          message & ":;" & 
+          "for: " & context
 
 # Runtime errors
 

--- a/src/vm/errors.nim
+++ b/src/vm/errors.nim
@@ -218,6 +218,10 @@ proc SyntaxError_EmptyLiteral*(lineno: int, context: string) =
 proc AssertionError_AssertionFailed*(context: string) =
     panic AssertionError,
           context
+          
+proc AssertionError_AssertionFailed*(context: string, message: string) =
+    panic AssertionError, 
+          "\"" & message & "\": " & context
 
 # Runtime errors
 

--- a/tests/errors/assertion.ensureWithCustomMessage.art
+++ b/tests/errors/assertion.ensureWithCustomMessage.art
@@ -1,2 +1,2 @@
-ensure.message: "Wrong calc" -> 0 = 1 - 1
-ensure.message: "Wrong calc" -> 0 = 1 + 1
+ensure.that: "Wrong calc" -> 0 = 1 - 1
+ensure.that: "Wrong calc" -> 0 = 1 + 1

--- a/tests/errors/assertion.ensureWithCustomMessage.art
+++ b/tests/errors/assertion.ensureWithCustomMessage.art
@@ -1,0 +1,2 @@
+ensure.message: "Wrong calc" -> 0 = 1 - 1
+ensure.message: "Wrong calc" -> 0 = 1 + 1

--- a/tests/errors/assertion.ensureWithCustomMessage.res
+++ b/tests/errors/assertion.ensureWithCustomMessage.res
@@ -1,4 +1,5 @@
 >> Assertion | File: assertion.ensureWithCustomMessage.art
        error | Line: 2
              | 
-             | "Wrong calc": [0 = 1 + 1]
+             | Wrong calc:
+             | for: [0 = 1 + 1]

--- a/tests/errors/assertion.ensureWithCustomMessage.res
+++ b/tests/errors/assertion.ensureWithCustomMessage.res
@@ -1,0 +1,2 @@
+>> Assertion | "Wrong calc": [0 = 1 + 1]
+       error | 

--- a/tests/errors/assertion.ensureWithCustomMessage.res
+++ b/tests/errors/assertion.ensureWithCustomMessage.res
@@ -1,2 +1,4 @@
->> Assertion | "Wrong calc": [0 = 1 + 1]
-       error | 
+>> Assertion | File: assertion.ensureWithCustomMessage.art
+       error | Line: 2
+             | 
+             | "Wrong calc": [0 = 1 + 1]


### PR DESCRIPTION
# Description

Adds an attribute to print a custom message when `ensure` fails.

Fixes #1061 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Update/create tests
- [x] Update/create usage example 
- [x] This change requires a documentation update