### PR TITLE
[Arithmetic\add & sub] doesn't work for `:color` literals

### DIFF
--- a/src/vm/values/value.nim
+++ b/src/vm/values/value.nim
@@ -1060,7 +1060,9 @@ proc `-=`*(x: var Value, y: Value) =
     ## store the result in the first value
     ## 
     ## **Hint:** In-place, mutating operation
-    if not (x.kind in {Integer, Floating, Complex, Rational}) or not (y.kind in {Integer, Floating, Complex, Rational}):
+    if x.kind==Color and y.kind==Color:
+        x.l = x.l - y.l 
+    elif not (x.kind in {Integer, Floating, Complex, Rational}) or not (y.kind in {Integer, Floating, Complex, Rational}):
         if x.kind == Quantity:
             if y.kind == Quantity:
                 if x.unit.name == y.unit.name:

--- a/src/vm/values/value.nim
+++ b/src/vm/values/value.nim
@@ -897,7 +897,9 @@ proc `+=`*(x: var Value, y: Value) =
     ## and store the result in the first value
     ## 
     ## **Hint:** In-place, mutating operation
-    if not (x.kind in {Integer, Floating, Complex, Rational}) or not (y.kind in {Integer, Floating, Complex, Rational}):
+    if x.kind==Color and y.kind==Color:
+        x.l = x.l + y.l
+    elif not (x.kind in {Integer, Floating, Complex, Rational}) or not (y.kind in {Integer, Floating, Complex, Rational}):
         if x.kind == Quantity:
             if y.kind == Quantity:
                 if x.unit.name == y.unit.name:


### PR DESCRIPTION
# Description

On my local build:

![image](https://user-images.githubusercontent.com/78623871/225111311-8dbdd533-c620-474c-a278-23105a504f78.png)


Fixes #1074, related to #1072

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Update tests on: #1072