### PR TITLE
[Converters\to] update usage examples for `:complex` and `:rational`

### DIFF
--- a/src/library/Converters.nim
+++ b/src/library/Converters.nim
@@ -1352,6 +1352,8 @@ proc defineSymbols*() =
             to :floating 4                ; 4.0
 
             to :complex [1 2]             ; 1.0+2.0i
+            
+            ; make sure you're using the `array` (`@`) converter here, since `neg` must be evaluated first
             to :complex @[2.3 neg 4.5]    ; 2.3-4.5i
             
             to :boolean 0                 ; false

--- a/src/library/Converters.nim
+++ b/src/library/Converters.nim
@@ -1356,6 +1356,9 @@ proc defineSymbols*() =
             ; make sure you're using the `array` (`@`) converter here, since `neg` must be evaluated first
             to :complex @[2.3 neg 4.5]    ; 2.3-4.5i
             
+            to :rational [1 2]            ; 1/2
+            to :rational @[neg 3 5]       ; -3/5
+            
             to :boolean 0                 ; false
             to :boolean 1                 ; true
             to :boolean "true"            ; true


### PR DESCRIPTION
# Description

This update explains why you **must** use `@` for negative fields when converting to `:rational`s and `:complex`es, and add missing example for `:rational` type. 🙂 

Related to #1075

## Type of change
- [x] Update documentation
- [x] This change requires a documentation update