### PR TITLE
[Collections\last] improve function's performance for range types

### DIFF
--- a/src/helpers/ranges.nim
+++ b/src/helpers/ranges.nim
@@ -105,6 +105,44 @@ func `[]`*(rng: VRange, idx: HSlice): ValueArray =
         )
         start += step
         i += 1
+        
+        
+func `[]`*(rng: VRange, idx: int, returnValue: bool): Value =
+    
+    if idx > rng.len or idx < 0: 
+        raise newException(ValueError, "Index out of range!!")
+
+    let step = 
+        if rng.forward: rng.step
+        else: -1 * rng.step
+    
+    return 
+        if rng.numeric: newInteger(rng.start + step*(idx - 1))
+        else: newChar(char(rng.start + step*(idx - 1)))
+    
+    
+        
+func `[]`*(rng: VRange, idx: HSlice, returnValue: bool): VRange =
+    
+    if idx.a > rng.len or idx.b > rng.len or idx.a < 0 or idx.b < 0: 
+        raise newException(ValueError, "Index out of range!!")
+
+    let step = 
+        if rng.forward: rng.step
+        else: -1 * rng.step
+
+    var start = rng.start + step*idx.a
+    var stop = rng.start + step*(idx.b-1)
+    
+    return VRange(
+            start:      start,
+            stop:       stop,
+            step:       rng.step,
+            infinite:   rng.infinite,
+            numeric:    rng.numeric,
+            forward:    rng.forward
+        )
+
 
 proc contains*(rng: VRange, v: Value): bool {.inline,enforceNoRaises.} =
     rng.find(v) >= 0

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -976,8 +976,11 @@ proc defineSymbols*() =
                     if x.s.len == 0: push(newString(""))
                     else: push(newString(x.s[x.s.len-aN.i..^1]))
                 elif x.kind == Range:
-                    let items = toSeq(x.rng.items)
-                    push(newBlock(items[x.rng.len-aN.i..^1]))
+                    if x.rng.infinite:
+                        push(newFloating(Inf))
+                    else:
+                        let items = toSeq(x.rng.items)
+                        push(newBlock(items[x.rng.len-aN.i..^1]))
                 else:
                     if x.a.len == 0: push(newBlock())
                     else: push(newBlock(x.a[x.a.len-aN.i..^1]))
@@ -986,8 +989,11 @@ proc defineSymbols*() =
                     if x.s.len == 0: push(VNULL)
                     else: push(newChar(toRunes(x.s)[^1]))
                 elif x.kind == Range:
-                    let items = toSeq(x.rng.items)
-                    push(items[x.rng.len-1])
+                    if x.rng.infinite:
+                        push(newFloating(Inf))
+                    else:
+                        let items = toSeq(x.rng.items)
+                        push(items[x.rng.len-1])
                 else:
                     if x.a.len == 0: push(VNULL)
                     else: push(x.a[x.a.len-1])

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -979,8 +979,7 @@ proc defineSymbols*() =
                     if x.rng.infinite:
                         push(newFloating(Inf))
                     else:
-                        let items = toSeq(x.rng.items)
-                        push(newBlock(items[x.rng.len-aN.i..^1]))
+                        push(newRange(x.rng[x.rng.len-aN.i..x.rng.len, true]))
                 else:
                     if x.a.len == 0: push(newBlock())
                     else: push(newBlock(x.a[x.a.len-aN.i..^1]))
@@ -992,10 +991,7 @@ proc defineSymbols*() =
                     if x.rng.infinite:
                         push(newFloating(Inf))
                     else:
-                        if x.rng.forward: 
-                            push(newInteger(x.rng.max()[1].i))
-                        else:
-                            push(newInteger(x.rng.min()[1].i))
+                        push(x.rng[x.rng.len, true])
                 else:
                     if x.a.len == 0: push(VNULL)
                     else: push(x.a[x.a.len-1])

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -992,7 +992,7 @@ proc defineSymbols*() =
                     if x.rng.infinite:
                         push(newFloating(Inf))
                     else:
-                        if x.rng.start < x.rng.stop: 
+                        if x.rng.forward: 
                             push(newInteger(x.rng.max()[1].i))
                         else:
                             push(newInteger(x.rng.min()[1].i))

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -992,8 +992,10 @@ proc defineSymbols*() =
                     if x.rng.infinite:
                         push(newFloating(Inf))
                     else:
-                        let items = toSeq(x.rng.items)
-                        push(items[x.rng.len-1])
+                        if x.rng.start < x.rng.stop: 
+                            push(newInteger(x.rng.max()[1].i))
+                        else:
+                            push(newInteger(x.rng.min()[1].i))
                 else:
                     if x.a.len == 0: push(VNULL)
                     else: push(x.a[x.a.len-1])

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -979,7 +979,10 @@ proc defineSymbols*() =
                     if x.rng.infinite:
                         push(newFloating(Inf))
                     else:
-                        push(newRange(x.rng[x.rng.len-aN.i..x.rng.len, true]))
+                        if aN.i == 1 or aN.i == 0:
+                            push(x.rng[x.rng.len, true])
+                        else:
+                            push(newRange(x.rng[x.rng.len-aN.i..x.rng.len, true]))
                 else:
                     if x.a.len == 0: push(newBlock())
                     else: push(newBlock(x.a[x.a.len-aN.i..^1]))

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -1148,6 +1148,8 @@ do [
     
     ensure -> 5 = last.n: 1 range 0 5
     ensure -> 0 = last.n: 1 range 5 0
+    ensure -> 5 = last.n: 0 range 0 5
+    ensure -> 0 = last.n: 0 range 5 0
     passed
 
     try? -> last.n: neg 2 range 0 5

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -1145,7 +1145,10 @@ do [
     ensure -> (2..0) = last.n: 3 range 5 0
     ensure -> (range.step: 2 3 1) = last.n: 2 range.step: 2 5 0
     passed
-
+    
+    ensure -> 5 = last.n: 1 range 0 5
+    ensure -> 0 = last.n: 1 range 5 0
+    passed
 
     try? -> last.n: neg 2 range 0 5
     else -> passed

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -1099,13 +1099,60 @@ do [
 
     ensure -> 10 = last 5..10
     passed
-    ensure -> (to :block 8..10) = last.n: 3 5..10
+    ensure -> (8..10) = last.n: 3 5..10
     passed
     
     ensure -> infinite = last 5..infinite
     passed
     ensure -> infinite = last.n: 2 5..infinite
     passed
+    
+    ; --- New tests for range
+    a: range 0 499
+    b: range.step: 2 0 499
+    c: range.step: 3 0 499
+
+    ensure -> 499 = last a
+    ensure -> 498 = last b
+    ensure -> 498 = last c
+    passed
+
+    ensure -> [497, 498, 499] = to :block last.n: 3 a
+    ensure -> [494, 496, 498] = to :block last.n: 3 b
+    ensure -> [492, 495, 498] = to :block last.n: 3 c
+    ensure -> (497..499) = last.n: 3 a
+    ensure -> (range.step: 2 494 498) = last.n: 3 b
+    ensure -> (range.step: 3 492 498) = last.n: 3 c
+    passed
+
+
+    a: range `a` `l`
+    b: range.step: 2 `a` `l`
+
+    ensure -> `l` = last a
+    ensure -> `k` = last b
+    passed
+
+    ensure -> [`k` `l`] = to :block last.n: 2 a
+    ensure -> [`i` `k`] = to :block last.n: 2 b
+    ensure -> (`k`..`l`) = last.n: 2 a
+    ensure -> (range.step: 2 `i` `k`) = last.n: 2 b
+    passed
+
+    ensure -> 1 = last range.step: 2 5 0
+    ensure -> [2 1 0] = to :block last.n: 3 range 5 0
+    ensure -> [3 1] = to :block last.n: 2 range.step: 2 5 0
+    ensure -> (2..0) = last.n: 3 range 5 0
+    ensure -> (range.step: 2 3 1) = last.n: 2 range.step: 2 5 0
+    passed
+
+
+    try? -> last.n: neg 2 range 0 5
+    else -> passed
+
+    try? -> last.n: 7 range 0 5
+    else -> passed
+    
 
 ]
 

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -1101,6 +1101,11 @@ do [
     passed
     ensure -> (to :block 8..10) = last.n: 3 5..10
     passed
+    
+    ensure -> infinite = last 5..infinite
+    passed
+    ensure -> infinite = last.n: 2 5..infinite
+    passed
 
 ]
 

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -372,6 +372,7 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
 
 >> max - [:integer] - .index
 [+] passed!

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -363,6 +363,8 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
+[+] passed!
 
 >> max - [:integer] - .index
 [+] passed!

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -365,6 +365,13 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
 
 >> max - [:integer] - .index
 [+] passed!


### PR DESCRIPTION
# Description

There is two problems here, the main problem is described in the issue #1097, and the other is described [in my comment](https://github.com/arturo-lang/arturo/issues/1097#issuecomment-1480090093).

1. `last` was internally trying to generate an infinite block to get the last element. Obviously it crashes, since we don't have infinite memory and it would iterate infinitely until **never** reaches the infinite number... (fixed on [9dd1577](https://github.com/arturo-lang/arturo/pull/1100/commits/9dd15775f69b8fc2d3e16a73cd3279a1108f3657))
2. even solving the 1st problem, it still generates a block (`O(n/step)` amortized) to get the last number, but **we just want the last number**.

Fixes #1097

## TODO

- [x] add case for infinite ranges
- [x] add case for last element
  - [x] cover chars
- [x] add case for the last n elements, returning a new range
  - [x] cover chars

## Type of change
- [x] Bug fix (~non~ breaking change which fixes an issue)
  - returns a `:range` instead of `:block` for `last.n`