### PR TITLE
[Collections\first] improve performance for range types, as it was for [Collections\last]

### DIFF
--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -512,7 +512,7 @@ proc defineSymbols*() =
                     else: push(newString(x.s[0..aN.i-1]))
                 elif x.kind == Range:
                     if aN.i == 1 or aN.i == 0:
-                        push(x.rng[0, true])
+                        push(x.rng[1, true])
                     else:
                         push(newRange(x.rng[0..aN.i, true]))
                 else:

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -505,19 +505,19 @@ proc defineSymbols*() =
             ..........
             print first.n:2 ["one" "two" "three"] ; one two
         """:
-            #=======================================================
+            #=======================================================            
             if checkAttr("n"):
                 if x.kind == String:
                     if x.s.len == 0: push(newString(""))
                     else: push(newString(x.s[0..aN.i-1]))
                 elif x.kind == Range:
-                    var res: ValueArray = newSeq[Value](aN.i)
-                    var i = 0
-                    for item in items(x.rng):
-                        res[i] = item
-                        i += 1
-                        if i == aN.i: break
-                    push(newBlock(res))
+                    if x.rng.infinite and not x.rng.forward:
+                        push(newFloating(Inf))
+                    else:
+                        if aN.i == 1 or aN.i == 0:
+                            push(x.rng[0, true])
+                        else:
+                            push(newRange(x.rng[0..aN.i, true]))
                 else:
                     if x.a.len == 0: push(newBlock())
                     else: push(newBlock(x.a[0..aN.i-1]))

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -511,13 +511,10 @@ proc defineSymbols*() =
                     if x.s.len == 0: push(newString(""))
                     else: push(newString(x.s[0..aN.i-1]))
                 elif x.kind == Range:
-                    if x.rng.infinite and not x.rng.forward:
-                        push(newFloating(Inf))
+                    if aN.i == 1 or aN.i == 0:
+                        push(x.rng[0, true])
                     else:
-                        if aN.i == 1 or aN.i == 0:
-                            push(x.rng[0, true])
-                        else:
-                            push(newRange(x.rng[0..aN.i, true]))
+                        push(newRange(x.rng[0..aN.i, true]))
                 else:
                     if x.a.len == 0: push(newBlock())
                     else: push(newBlock(x.a[0..aN.i-1]))

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -581,6 +581,58 @@ do [
     passed
     ensure -> (to :block 5..7) = first.n: 3 5..10
     passed
+    
+    
+    ; --- New tests for range
+    a: range 0 499
+    b: range.step: 2 1 499
+    c: range.step: 3 2 499
+
+    ensure -> 0 = first a
+    ensure -> 1 = first b
+    ensure -> 2 = first c
+    passed
+
+    ensure -> [0 1 2] = @first.n: 3 a
+    ensure -> [1 3 5] = @first.n: 3 b
+    ensure -> [2 5 8] = @first.n: 3 c
+    ensure -> (0..2) = first.n: 3 a
+    ensure -> (range.step: 2 1 5) = first.n: 3 b
+    ensure -> (range.step: 3 2 8) = first.n: 3 c
+    passed
+
+
+    a: range `a` `l`
+    b: range.step: 2 `a` `l`
+
+    ensure -> `a` = first a
+    ensure -> `a` = first b
+    passed
+
+    ensure -> [`a` `b`] = @first.n: 2 a
+    ensure -> [`a` `c`] = @first.n: 2 b
+    ensure -> (`a`..`b`) = first.n: 2 a
+    ensure -> (range.step: 2 `a` `c`) = first.n: 2 b
+    passed
+
+    ensure -> 5 = first range.step: 2 5 0
+    ensure -> [5 4 3] = @first.n: 3 range 5 0
+    ensure -> [5 3] = @first.n: 2 range.step: 2 5 0
+    ensure -> (5..3) = first.n: 3 range 5 0
+    ensure -> (range.step: 2 5 3) = first.n: 2 range.step: 2 5 0
+    passed
+    
+    ensure -> 0 = first.n: 1 range 0 5
+    ensure -> 5 = first.n: 1 range 5 0
+    ensure -> 0 = first.n: 0 range 0 5
+    ensure -> 5 = first.n: 0 range 5 0
+    passed
+
+    try? -> first.n: neg 2 range 0 5
+    else -> passed
+
+    try? -> first.n: 7 range 0 5
+    else -> passed
 
 ]
 

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -579,7 +579,7 @@ do [
 
     ensure -> 5 = first 5..10
     passed
-    ensure -> (to :block 5..7) = first.n: 3 5..10
+    ensure -> (to :block 5..7) = @first.n: 3 5..10
     passed
     
     

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -199,6 +199,14 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
 
 >> flatten
 [+] passed!


### PR DESCRIPTION
# Description

As `first` works as `last`, we should update it too. So, I did it! 
Now, it returns a `:range` instead of a `:block` while using `first.n: :integer :range`, and also as it doesn't create a `:block` anymore, it can be considered a performance improvement for large ranges...

- Related with #1100 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Add/Update unit-tests