### PR TITLE
[Converters\to] fix behavior when converting erroneous Block -> Complex/Rational

### DIFF
--- a/src/library/Converters.nim
+++ b/src/library/Converters.nim
@@ -332,7 +332,11 @@ proc convertedValueToType(x, y: Value, tp: ValueKind, aFormat:Value = nil): Valu
                         else:
                             throwCannotConvert()
                     of Rational:
-                        return newRational(y.a[0], y.a[1])
+                        if (y.a[0].kind in {Floating, Integer} and
+                            y.a[1].kind in {Floating, Integer}):
+                            return newRational(y.a[0], y.a[1])
+                        else:
+                            throwCannotConvert()
                     of Inline:
                         return newInline(y.a)
                     of Dictionary:

--- a/src/library/Converters.nim
+++ b/src/library/Converters.nim
@@ -326,7 +326,11 @@ proc convertedValueToType(x, y: Value, tp: ValueKind, aFormat:Value = nil): Valu
             of Block:
                 case tp:
                     of Complex:
-                        return newComplex(y.a[0], y.a[1])
+                        if (y.a[0].kind in {Floating, Integer} and
+                            y.a[1].kind in {Floating, Integer}):
+                            return newComplex(y.a[0], y.a[1])
+                        else:
+                            throwCannotConvert()
                     of Rational:
                         return newRational(y.a[0], y.a[1])
                     of Inline:

--- a/src/library/Converters.nim
+++ b/src/library/Converters.nim
@@ -326,13 +326,15 @@ proc convertedValueToType(x, y: Value, tp: ValueKind, aFormat:Value = nil): Valu
             of Block:
                 case tp:
                     of Complex:
-                        if (y.a[0].kind in {Floating, Integer} and
+                        if (y.a.len == 2 and
+                            y.a[0].kind in {Floating, Integer} and
                             y.a[1].kind in {Floating, Integer}):
                             return newComplex(y.a[0], y.a[1])
                         else:
                             throwCannotConvert()
                     of Rational:
-                        if (y.a[0].kind in {Floating, Integer} and
+                        if (y.a.len == 2 and
+                            y.a[0].kind in {Floating, Integer} and
                             y.a[1].kind in {Floating, Integer}):
                             return newRational(y.a[0], y.a[1])
                         else:

--- a/tests/unittests/lib.converters.art
+++ b/tests/unittests/lib.converters.art
@@ -1,0 +1,28 @@
+topic: $[topic :string] -> print ~"\n>> |topic|"
+passed: $[] -> print "[+] passed!"
+
+
+topic "to" do
+[
+
+    topic "to - invalid operations"
+
+    ; invalid :complex operations
+    ensure -> every? @[
+        -> to :complex [neg 1 2]
+        -> to :complex [1 neg 2]
+        -> to :complex []
+        -> to :complex [1 2 3]
+    ] => throws?
+    passed
+
+    ; invalid :rational oprations
+    ensure -> every? @[
+        -> to :rational [neg 1 2]
+        -> to :rational [1 neg 2]
+        -> to :rational []
+        -> to :rational [1 2 3]
+    ] => throws?
+    passed
+
+]


### PR DESCRIPTION
# Description

This PR properly closes (the already closed) #1075. Basically, try to convert an improper `:block` causes an undefined behavior, what is the worst case as possible to a production code.

- Fixes #1075

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] App/Update unit-test 