### PR TITLE
[Collections\split] fix `split.at` for literal values

### DIFF
--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2096,7 +2096,7 @@ proc defineSymbols*() =
                                 $(w))))
                 else:
                     if checkAttr("at"):
-                        SetInPlace(newBlock(@[newBlock(InPlaced.a[0..aAt.i]),
+                        SetInPlace(newBlock(@[newBlock(InPlaced.a[0..aAt.i-1]),
                                 newBlock(InPlaced.a[aAt.i..^1])]))
                     elif checkAttr("every"):
                         var ret: ValueArray

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -2780,12 +2780,10 @@ do [
     ensure -> ["hell" "oworld"] = a
     passed
     
-    ; Not working for literals
-    ; a: ["Arturo" " Nim" " Ruby" " Python", " C", " CoffeeScript"], split.at: 4 'a
-    ; print as.code a ; => [["Arturo" " Nim" " Ruby" " Python" " C"] [" C" " CoffeeScript"]]
-    ; ensure -> [["Arturo" " Nim" " Ruby" " Python"] [" C" " CoffeeScript"]] = a
-    ; passed
-    
+    a: ["Arturo" " Nim" " Ruby" " Python", " C", " CoffeeScript"], split.at: 4 'a
+    ensure -> [["Arturo" " Nim" " Ruby" " Python"] [" C" " CoffeeScript"]] = a
+    passed
+
 ]
 
 topic "split - .path"

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -737,6 +737,7 @@
 
 >> split - .at (literal)
 [+] passed!
+[+] passed!
 
 >> split - .path
 [+] passed!


### PR DESCRIPTION
# Description

> It should have the same behavior as for non-literals.
>
> ```red
> $> a: ["Arturo" " Nim" " Ruby" " Python", " C", " CoffeeScript"]
> $> split.at: 4 'a
> $> a
> ; => [[Arturo  Nim  Ruby  Python  C] [ C  CoffeeScript]]
> $> b: ["Arturo" " Nim" " Ruby" " Python", " C", " CoffeeScript"]
> $> split.at: 4 b
> ; => [[Arturo  Nim  Ruby  Python] [ C  CoffeeScript]]
> ```

- Fixes #1118
- Related to #669

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Add/Update unit-test