### PR TITLE
WIP - [Numbers\clamp] use Range instead of `min`/`max` as parameter

### DIFF
--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -393,13 +393,7 @@ proc defineSymbols*() =
             #=======================================================
             push(newInteger(int(ceil(asFloat(x)))))
 
-    # TODO(Numbers/clamp) use a Range instead of min/max, as parameters
-    #  given how elegantly Range values are used, it would be better to use e.g a `range` 
-    #  Range type parameter for this one instead of a `max` and `min` parameter, so that we
-    #  we could do something along the lines of `clamp 2 1..3` (would return 2) or 
-    #  `clamp 4 1..3` (would return 3) or `clamp 0 1..3` (would return 1); same as before.
-    #  Also, should we reverse the order of the params, and have the range as the first one?
-    #  labels: library, enhancement
+
     builtin "clamp",
         alias       = unaliased, 
         op          = opNop,

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -29,6 +29,7 @@ when not defined(NOGMP):
 
 import helpers/maths
 import helpers/ranges
+import vm/values/custom/vrange
 
 import vm/errors
 
@@ -406,8 +407,7 @@ proc defineSymbols*() =
         description = "force value within given range",
         args        = {
             "number" : {Integer,Floating},
-            "min"    : {Integer,Floating},
-            "max"    : {Integer,Floating}
+            "range"  : {Range}
         },
         attrs       = NoAttrs,
         returns     = {Integer,Floating},
@@ -417,12 +417,15 @@ proc defineSymbols*() =
             clamp 4 1 3             ; 3
         """:
             #=======================================================
-            if x < y:
-                push(y)
-            elif x > z:
-                push(z)
+            if y.rng.forward:
+                if x.i < y.rng.start: push(newInteger(y.rng.start))
+                elif x.i > y.rng[y.rng.len, true].i: push(newInteger(y.rng[y.rng.len, true].i))
+                else: push(x)
             else:
-                push(x)
+                if x.i > y.rng.start: push(newInteger(y.rng.start))
+                elif x.i < y.rng[y.rng.len, true].i: push(newInteger(y.rng[y.rng.len, true].i))
+                else: push(x)
+            
 
     builtin "conj",
         alias       = unaliased, 

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -412,9 +412,11 @@ proc defineSymbols*() =
         attrs       = NoAttrs,
         returns     = {Integer,Floating},
         example     = """
-            clamp 2 1 3             ; 2
-            clamp 0 1 3             ; 1
-            clamp 4 1 3             ; 3
+            clamp 2 1..3                ; 2
+            clamp 0 1..3                ; 1
+            clamp 4 1..3                ; 3
+            clamp 4 3..1                ; 3
+            clamp 5 range.step: 2 1 5   ; 4
         """:
             #=======================================================
             if y.rng.forward:

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -1,0 +1,31 @@
+topic: $[topic :string] -> print ~"\n>> |topic|"
+passed: $[] -> print "[+] passed!"
+
+topic « clamp
+do [
+    
+    ensure.that: "is inside the range" 
+    -> 1 = clamp 1 0..2
+    ensure.that: "is inside the range" 
+    -> 1 = clamp 1 2..0
+    passed
+    
+    ensure.that: "is outside and is greather than range" 
+    -> 1 = clamp 2 0..1
+    ensure.that: "is outside and is greather than range" 
+    -> 1 = clamp 2 1..0
+    passed
+    
+    ensure.that: "is outside and is greather than range" 
+    -> 1 = clamp 0 1..2
+    ensure.that: "is outside and is greather than range" 
+    -> 1 = clamp 0 2..1
+    passed
+    
+    ensure.that: "is outiside and is greather than a range with step" 
+    -> 4 = clamp 5 range.step: 2 0 5
+    ensure.that: "is outiside and is greather than a range with step" 
+    -> 5 = clamp 5 range.step: 2 5 0
+    passed
+    
+]

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -4,27 +4,27 @@ passed: $[] -> print "[+] passed!"
 topic « clamp
 do [
     
-    ensure.that: "is inside the range" 
+    ensure.that: "is inside of the range" 
     -> 1 = clamp 1 0..2
-    ensure.that: "is inside the range" 
+    ensure.that: "is inside of a reversed range" 
     -> 1 = clamp 1 2..0
     passed
     
     ensure.that: "is outside and is greather than range" 
     -> 1 = clamp 2 0..1
-    ensure.that: "is outside and is greather than range" 
+    ensure.that: "is outside and is greather than reversed range" 
     -> 1 = clamp 2 1..0
     passed
     
     ensure.that: "is outside and is greather than range" 
     -> 1 = clamp 0 1..2
-    ensure.that: "is outside and is greather than range" 
+    ensure.that: "is outside and is greather than reversed range" 
     -> 1 = clamp 0 2..1
     passed
     
     ensure.that: "is outiside and is greather than a range with step" 
     -> 4 = clamp 5 range.step: 2 0 5
-    ensure.that: "is outiside and is greather than a range with step" 
+    ensure.that: "is outiside and is greather than a reversed range with step" 
     -> 5 = clamp 5 range.step: 2 5 0
     passed
     

--- a/tests/unittests/lib.numbers.res
+++ b/tests/unittests/lib.numbers.res
@@ -1,0 +1,6 @@
+
+>> clamp
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!


### PR DESCRIPTION
# Description

Changes:
- [x] `clamp` accepts a range instead of two parameters.
  - [x] should work with reversed range
  - [x] should work for range with step different of 1
  - [ ] Should work with `:char`s
  - [ ] Should not work for `:floating` as first parameter, since `:range`s doesn't accept

- Fixes #1122

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Add/Update unit-tests