### PR TITLE
Add unit-test for Comparison Library

### DIFF
--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -4937,17 +4937,18 @@ do [
     
     topic « less? - :word
     
-    ; ensure -> less? [a] [b]
-    a: [a]
-    b: [b]
-    ensure -> less? a\0 b\0
-    ensure -> not? less? [word] [word]
-    ensure -> not? less? [word] [otherWord]
-    ensure -> not? less? [word] ["word"]
-    ensure -> not? less? [word] [word:]
-    ensure -> not? less? [word] ['word]
-    ; ensure -> not? less? [word] [.word]
-    ensure -> not? less? [word] [.word:]
+    ensure -> less? to :word "a" to :word "b"
+    ensure -> not? less? to :word "a" to :word "a"
+    ensure -> not? less? to :word "b" to :word "a"
+    passed
+    
+    ensure -> not? less? to :word "a" "b"
+    ensure -> not? less? to :word "a" `b`
+    ensure -> not? less? to :word "a" 'b
+    ensure -> not? less? to :word "a" to :label "b"
+    ensure -> not? less? to :word "a" to :attribute "b"
+    ensure -> not? less? to :word "a" to :attributeLabel "b"
+    ensure -> not? less? to :word "word" to :type "z"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2567,38 +2567,20 @@ do [
     passed
     
     
-    topic « Equal? - :label
+    topic « greater? - :label
     
-    ensure -> not? greater? [a:] [b:]
-    ; ensure -> greater? [b:] [a:]
-    a: [a:]
-    b: [b:]
-    ; ensure -> greater? a\0 b\0
-    ensure -> not? greater? [label: value] [label: value]
+    ensure -> greater? to :label "b" to :label "a"
+    ensure -> not? greater? to :label "a" to :label "a"
+    ensure -> not? greater? to :label "a" to :label "b"
     passed
     
-    ensure -> not? greater? [label: value] [label: value2]
-    ensure -> not? greater? [label: value] [label2: value]
-    passed
-    
-    ensure -> not? greater? [label:] ["label"]
-    ensure -> not? greater? ["label":] ["label"]
-    ensure -> not? greater? [label:] ["value"]
-    ensure -> not? greater? [label:] ["value"]
-    ensure -> not? greater? [label: "value"] ["label" "value"]
-    passed
-    
-    ; ensure -> not? greater? [label:] [label]
-    ensure -> not? greater? [label:] [value]
-    ensure -> not? greater? [label: "value"] [label value]
-    passed
-    
-    ensure -> not? greater? [label:] ['label]
-    ensure -> not? greater? [label: 'world] ['label 'word]
-    passed
-    
-    ; ensure -> not? greater? [label: .attr] [.label .attr]
-    ; ensure -> not? greater? [label: .attr: "a"] [.label: .attr: "a"]
+    ensure -> not? greater? to :label "a" "a"
+    ensure -> not? greater? to :label "a" `a`
+    ensure -> not? greater? to :label "a" 'a
+    ensure -> not? greater? to :label "a" to :word "a"
+    ensure -> not? greater? to :label "a" to :attribute "a"
+    ensure -> not? greater? to :label "a" to :attributeLabel "a"
+    ensure -> not? greater? to :label "word" to :type "word"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -6111,20 +6111,20 @@ do [
     ensure -> lessOrEqual? "Art" "Artu"
     passed
     
-    ensure -> not? lessOrEqual? "a"    `a` 
-    ensure -> not? lessOrEqual? "10"   10 
-    ensure -> not? lessOrEqual? "10"   10
-    ensure -> not? lessOrEqual? ["help"] [help]
-    ensure -> not? lessOrEqual? ["a"]    [a:]
-    ensure -> not? lessOrEqual? "help"   'help
-    ensure -> not? lessOrEqual? ["help"] [.help]
-    ensure -> not? "a"      =< `a` 
-    ensure -> not? "10"     =< 10 
-    ensure -> not? "10"     =< 10
-    ensure -> not? ["help"] =< [help]
-    ensure -> not? ["a"]    =< [a:]
-    ensure -> not? "help"   =< 'help
-    ensure -> not? ["help"] =< [.help]
+    ensure -> not? lessOrEqual? "a" `a`
+    ensure -> not? lessOrEqual? "a" `b`
+    ensure -> not? lessOrEqual? "a" 'a
+    ensure -> not? lessOrEqual? "a" 'b
+    ensure -> not? lessOrEqual? "a" to :word "a"
+    ensure -> not? lessOrEqual? "a" to :word "b"
+    ensure -> not? lessOrEqual? "a" to :label "a"
+    ensure -> not? lessOrEqual? "a" to :label "b"
+    ensure -> not? lessOrEqual? "a" to :attribute "a"
+    ensure -> not? lessOrEqual? "a" to :attribute "b"
+    ensure -> not? lessOrEqual? "a" to :attributeLabel "a"
+    ensure -> not? lessOrEqual? "a" to :attributeLabel "b"
+    ensure -> not? lessOrEqual? "a" to :type "a"
+    ensure -> not? lessOrEqual? "a" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -4987,13 +4987,18 @@ do [
     topic « less? - :literal
     
     ensure -> less? 'a 'b
-    ensure -> not? less? 'literal 'literal
-    ensure -> less? 'literal 'other
-    ensure -> not? less? 'literal "literal"
-    ensure -> not? less? ['literal] ["literal"]
-    ensure -> not? less? ['literal] [literal]
-    ensure -> not? less? ['literal] [.literal]
-    ensure -> not? less? ['literal] [literal:]
+    ensure -> not? less? 'b 'a
+    ensure -> not? less? 'a 'a
+    ensure -> not? less? 'b 'b
+    passed
+    
+    ensure -> not? less? 'a "b"
+    ensure -> not? less? 'a `b`
+    ensure -> not? less? 'a to :word "b"
+    ensure -> not? less? 'a to :label "b"
+    ensure -> not? less? 'a to :attribute "b"
+    ensure -> not? less? 'a to :attributeLabel "b"
+    ensure -> not? less? 'a to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -8337,13 +8337,17 @@ do [
     
     topic « same? - :attribute
     
-    ensure -> same? [.attr] [.attr]
-    ensure -> not? same? [.attr] ["attr"]
-    ; ensure -> not? same? [.attr] [attr]
-    ensure -> not? same? [.attr] [attr: .attr]
-    ensure -> not? same? [.attr] ['attr]
-    ensure -> not? same? [.attr] [.other]
-    ensure -> not? same? [.attr] [.attr: .attr]
+    ensure -> same? to :attribute "a" to :attribute "a"
+    ensure -> not? same? to :attribute "a" to :attribute "b"
+    passed
+    
+    ensure -> not? same? to :attribute "a" "a"
+    ensure -> not? same? to :attribute "a" `a`
+    ensure -> not? same? to :attribute "a" 'a
+    ensure -> not? same? to :attribute "a" to :word "a"
+    ensure -> not? same? to :attribute "a" to :label "a"
+    ensure -> not? same? to :attribute "a" to :attributelabel "a"
+    ensure -> not? same? to :attribute "label" to :type "label"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2658,30 +2658,18 @@ do [
     
     topic « greaterOrEqual? - :attributeLabel
     
-    ensure -> not? greater? [.attr: value] [.attr: value]
-    ; ensure -> greater? [.b:] [.a:]
+    ; ensure -> greater? to :attributeLabel "b" to :attributeLabel "a"
+    ensure -> not? greater? to :attributeLabel "a" to :attributeLabel "a"
+    ensure -> not? greater? to :attributeLabel "a" to :attributeLabel "b"
     passed
     
-    ensure -> not? greater? [.attr:] ["attr"]
-    ensure -> not? greater? [.attr:] ["value"]
-    ensure -> not? greater? [.attr: value] ["attr" "value"]
-    passed
-    
-    ; ensure -> not? greater? [.attr:] [attr]
-    ensure -> not? greater? [.attr: value] [attr: .attr:]
-    ; ensure -> not? greater? [.attr: value] [attr: value]
-    ensure -> not? greater? [.attr: value] [attr: .attr:]
-    passed
-    
-    ensure -> not? greater? [.attr:] ['attr]
-    ensure -> not? greater? [.attr:] ['value]
-    ensure -> not? greater? [.attr: value] ['attr 'value]
-    passed
-    
-    ; ensure -> not? greater? [.attr:] [.attr]
-    ensure -> not? greater? [.attr:] [.value]
-    ensure -> not? greater? [.attr: value] [.other: value]
-    ensure -> not? greater? [.attr: value] [.attr: other]
+    ensure -> not? greater? to :attributeLabel "a" "a"
+    ensure -> not? greater? to :attributeLabel "a" `a`
+    ensure -> not? greater? to :attributeLabel "a" 'a
+    ensure -> not? greater? to :attributeLabel "a" to :word "a"
+    ensure -> not? greater? to :attributeLabel "a" to :label "a"
+    ensure -> not? greater? to :attributeLabel "a" to :attribute "a"
+    ensure -> not? greater? to :attributeLabel "word" to :type "word"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2534,20 +2534,14 @@ do [
     ensure -> greater? "Artu" "Art"
     passed
     
-    ensure -> not? greater? "a"    `a` 
-    ensure -> not? greater? "10"   10 
-    ensure -> not? greater? "10"   10
-    ensure -> not? greater? ["help"] [help]
-    ensure -> not? greater? ["a"]    [a:]
-    ensure -> not? greater? "help"   'help
-    ensure -> not? greater? ["help"] [.help]
-    ensure -> not? "a"      > `a` 
-    ensure -> not? "10"     > 10 
-    ensure -> not? "10"     > 10
-    ensure -> not? ["help"] > [help]
-    ensure -> not? ["a"]    > [a:]
-    ensure -> not? "help"   > 'help
-    ensure -> not? ["help"] > [.help]
+    ensure -> not? greater? "a" `a`
+    ensure -> not? greater? "a" 'a
+    ensure -> not? greater? "a" to :word "a"
+    ensure -> not? greater? "a" to :label "a"
+    ensure -> not? greater? "a" to :attribute "a"
+    ensure -> not? greater? "a" to :attributeLabel "a"
+    ensure -> not? greater? "string" to :type "string"
+    passed
     passed
     
     topic « greater? - :word

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -539,11 +539,11 @@ do [
     passed
     
     
-    topic « between? - :attributeLabel
+    topic « between? - :attributelabel
     
-    ensure -> between? to :attributeLabel "C" to :attributeLabel "Arturo" to :attributeLabel "Ruby"
-    ; ensure -> not? between? to :attributeLabel "C" to :attributeLabel "Arturo" to :attributeLabel "Barry"
-    ; ensure -> not? between? to :attributeLabel "C" to :attributeLabel "Python" to :attributeLabel "Ruby"
+    ensure -> between? to :attributelabel "C" to :attributelabel "Arturo" to :attributelabel "Ruby"
+    ; ensure -> not? between? to :attributelabel "C" to :attributelabel "Arturo" to :attributelabel "Barry"
+    ; ensure -> not? between? to :attributelabel "C" to :attributelabel "Python" to :attributelabel "Ruby"
     passed
     
     
@@ -1385,7 +1385,7 @@ do [
     ensure -> not? equal? "a" 'a
     ensure -> not? equal? "a" to :label "a"
     ensure -> not? equal? "a" to :attribute "a"
-    ensure -> not? equal? "a" to :attributeLabel "a"
+    ensure -> not? equal? "a" to :attributelabel "a"
     ensure -> not? equal? "string" to :type "string"
     passed
     
@@ -1401,7 +1401,7 @@ do [
     ensure -> not? equal? to :word "a" 'a
     ensure -> not? equal? to :word "a" to :label "a"
     ensure -> not? equal? to :word "a" to :attribute "a"
-    ensure -> not? equal? to :word "a" to :attributeLabel "a"
+    ensure -> not? equal? to :word "a" to :attributelabel "a"
     ensure -> not? equal? to :word "word" to :type "word"
     passed
     
@@ -1417,7 +1417,7 @@ do [
     ensure -> not? equal? to :label "a" 'a
     ensure -> not? equal? to :label "a" to :word "a"
     ensure -> not? equal? to :label "a" to :attribute "a"
-    ensure -> not? equal? to :label "a" to :attributeLabel "a"
+    ensure -> not? equal? to :label "a" to :attributelabel "a"
     ensure -> not? equal? to :label "label" to :type "label"
     passed
     
@@ -1433,7 +1433,7 @@ do [
     ensure -> not? equal? 'a to :label "a"
     ensure -> not? equal? 'a to :word "a"
     ensure -> not? equal? 'a to :attribute "a"
-    ensure -> not? equal? 'a to :attributeLabel "a"
+    ensure -> not? equal? 'a to :attributelabel "a"
     ensure -> not? equal? to :literal "literal" to :type "literal"
     passed
 
@@ -1450,24 +1450,24 @@ do [
     ensure -> not? equal? to :attribute "a" 'a
     ensure -> not? equal? to :attribute "a" to :word "a"
     ensure -> not? equal? to :attribute "a" to :label "a"
-    ensure -> not? equal? to :attribute "a" to :attributeLabel "a"
+    ensure -> not? equal? to :attribute "a" to :attributelabel "a"
     ensure -> not? equal? to :attribute "label" to :type "label"
     passed
     
     
-    topic « equal? - :attributeLabel
+    topic « equal? - :attributelabel
     
-    ensure -> equal? to :attributeLabel "a" to :attributeLabel "a"
-    ensure -> not? equal? to :attributeLabel "a" to :attributeLabel "b"
+    ensure -> equal? to :attributelabel "a" to :attributelabel "a"
+    ensure -> not? equal? to :attributelabel "a" to :attributelabel "b"
     passed
     
-    ensure -> not? equal? to :attributeLabel "a" "a"
-    ensure -> not? equal? to :attributeLabel "a" `a`
-    ensure -> not? equal? to :attributeLabel "a" 'a
-    ensure -> not? equal? to :attributeLabel "a" to :word "a"
-    ensure -> not? equal? to :attributeLabel "a" to :label "a"
-    ensure -> not? equal? to :attributeLabel "a" to :attribute "a"
-    ensure -> not? equal? to :attributeLabel "label" to :type "label"
+    ensure -> not? equal? to :attributelabel "a" "a"
+    ensure -> not? equal? to :attributelabel "a" `a`
+    ensure -> not? equal? to :attributelabel "a" 'a
+    ensure -> not? equal? to :attributelabel "a" to :word "a"
+    ensure -> not? equal? to :attributelabel "a" to :label "a"
+    ensure -> not? equal? to :attributelabel "a" to :attribute "a"
+    ensure -> not? equal? to :attributelabel "label" to :type "label"
     passed
     
     
@@ -1990,7 +1990,7 @@ do [
         -> equal? [:type] [type:]                   -> equal? [:label] [label:]
         -> equal? :1 '1                             -> equal? :literal '1                       
         -> equal? [:type] [.type]                   -> equal? [:attribute] [.type]              
-        -> equal? [:type] [.type:]                  -> equal? [:attributeLabel] [.type:]               
+        -> equal? [:type] [.type:]                  -> equal? [:attributelabel] [.type:]               
         -> equal? [:type] [type\type]               -> equal? [:path] [type\type]
         -> equal? [:type] [type\type:]              -> equal? [:pathLabel] [type\type:]            
         -> equal? [:type] [+]                       -> equal? [:symbol] [+]                     
@@ -2091,7 +2091,7 @@ do [
         -> equal? [.var]      @[var 'word?]            -> equal? [.word]     @[var 'word?]
     ] => not? passed
     
-    ; for :attributeLabel
+    ; for :attributelabel
     ensure -> every? @[           
         -> equal? [.rational:] @[to :rational [1 1]]    -> equal? [.null:]     @[null]                  
         -> equal? [.true:]     @[true]                  -> equal? [.false:]    @[false]                 
@@ -2541,7 +2541,7 @@ do [
     ensure -> not? greater? "b" to :word "a"
     ensure -> not? greater? "b" to :label "a"
     ensure -> not? greater? "b" to :attribute "a"
-    ensure -> not? greater? "b" to :attributeLabel "a"
+    ensure -> not? greater? "b" to :attributelabel "a"
     ensure -> not? greater? "b" to :type "a"
     passed
     
@@ -2557,7 +2557,7 @@ do [
     ensure -> not? greater? to :word "b" 'a
     ensure -> not? greater? to :word "b" to :label "a"
     ensure -> not? greater? to :word "b" to :attribute "a"
-    ensure -> not? greater? to :word "b" to :attributeLabel "a"
+    ensure -> not? greater? to :word "b" to :attributelabel "a"
     ensure -> not? greater? to :word "b" to :type "a"
     passed
     
@@ -2574,7 +2574,7 @@ do [
     ensure -> not? greater? to :label "b" 'a
     ensure -> not? greater? to :label "b" to :word "a"
     ensure -> not? greater? to :label "b" to :attribute "a"
-    ensure -> not? greater? to :label "b" to :attributeLabel "a"
+    ensure -> not? greater? to :label "b" to :attributelabel "a"
     ensure -> not? greater? to :label "b" to :type "a"
     passed
     
@@ -2591,7 +2591,7 @@ do [
     ensure -> not? greater? 'b to :word "a"
     ensure -> not? greater? 'b to :label "a"
     ensure -> not? greater? 'b to :attribute "a"
-    ensure -> not? greater? 'b to :attributeLabel "a"
+    ensure -> not? greater? 'b to :attributelabel "a"
     ensure -> not? greater? 'b to :type "a"
     passed
     
@@ -2646,25 +2646,25 @@ do [
     ensure -> not? greater? to :attribute "b" 'a
     ensure -> not? greater? to :attribute "b" to :word "a"
     ensure -> not? greater? to :attribute "b" to :label "a"
-    ensure -> not? greater? to :attribute "b" to :attributeLabel "a"
+    ensure -> not? greater? to :attribute "b" to :attributelabel "a"
     ensure -> not? greater? to :attribute "b" to :type "a"
     passed
 
     
-    topic « greater? - :attributeLabel
+    topic « greater? - :attributelabel
     
-    ; ensure -> greater? to :attributeLabel "b" to :attributeLabel "a"
-    ensure -> not? greater? to :attributeLabel "a" to :attributeLabel "a"
-    ensure -> not? greater? to :attributeLabel "a" to :attributeLabel "b"
+    ; ensure -> greater? to :attributelabel "b" to :attributelabel "a"
+    ensure -> not? greater? to :attributelabel "a" to :attributelabel "a"
+    ensure -> not? greater? to :attributelabel "a" to :attributelabel "b"
     passed
     
-    ensure -> not? greater? to :attributeLabel "less" "a"
-    ensure -> not? greater? to :attributeLabel "less" `a`
-    ensure -> not? greater? to :attributeLabel "less" 'a
-    ensure -> not? greater? to :attributeLabel "less" to :word "a"
-    ensure -> not? greater? to :attributeLabel "less" to :label "a"
-    ensure -> not? greater? to :attributeLabel "less" to :attribute "a"
-    ensure -> not? greater? to :attributeLabel "b" 
+    ensure -> not? greater? to :attributelabel "less" "a"
+    ensure -> not? greater? to :attributelabel "less" `a`
+    ensure -> not? greater? to :attributelabel "less" 'a
+    ensure -> not? greater? to :attributelabel "less" to :word "a"
+    ensure -> not? greater? to :attributelabel "less" to :label "a"
+    ensure -> not? greater? to :attributelabel "less" to :attribute "a"
+    ensure -> not? greater? to :attributelabel "b" 
                             to :type "a"
     passed
     
@@ -3146,7 +3146,7 @@ do [
         -> greater? [:type] [type:]                 -> greater? [:label] [label:]
         -> greater? :1 '1.                          -> greater? :literal '1                       
         -> greater? [:type] [.type]                 -> greater? [:attribute] [.type]              
-        -> greater? [:type] [.type:]                -> greater? [:attributeLabel] [.type:]                
+        -> greater? [:type] [.type:]                -> greater? [:attributelabel] [.type:]                
         -> greater? [:type] [type\type]             -> greater? [:path] [type\type]
         -> greater? [:type] [type\type:]            -> greater? [:pathLabel] [type\type:]            
         -> greater? [:type] [+]                     -> greater? [:symbol] [+]                     
@@ -3247,7 +3247,7 @@ do [
         -> greater? [.var]      @[var 'word?]            -> greater? [.word]     @[var 'word?]
     ] => not? passed
     
-    ; for :attributeLabel
+    ; for :attributelabel
     ensure -> every? @[           
         -> greater? [.rational:] @[to :rational [1 1]]    -> greater? [.null:]     @[null]                  
         -> greater? [.true:]     @[true]                  -> greater? [.false:]    @[false]                 
@@ -3718,8 +3718,8 @@ do [
     ensure -> not? greaterOrEqual? "b" to :label "b"
     ensure -> not? greaterOrEqual? "b" to :attribute "a"
     ensure -> not? greaterOrEqual? "b" to :attribute "b"
-    ensure -> not? greaterOrEqual? "b" to :attributeLabel "a"
-    ensure -> not? greaterOrEqual? "b" to :attributeLabel "b"
+    ensure -> not? greaterOrEqual? "b" to :attributelabel "a"
+    ensure -> not? greaterOrEqual? "b" to :attributelabel "b"
     ensure -> not? greaterOrEqual? "b" to :type "a"
     ensure -> not? greaterOrEqual? "b" to :type "b"
     passed
@@ -3743,8 +3743,8 @@ do [
     ensure -> not? greaterOrEqual? to :word "b" to :label "b"
     ensure -> not? greaterOrEqual? to :word "b" to :attribute "a"
     ensure -> not? greaterOrEqual? to :word "b" to :attribute "b"
-    ensure -> not? greaterOrEqual? to :word "b" to :attributeLabel "a"
-    ensure -> not? greaterOrEqual? to :word "b" to :attributeLabel "b"
+    ensure -> not? greaterOrEqual? to :word "b" to :attributelabel "a"
+    ensure -> not? greaterOrEqual? to :word "b" to :attributelabel "b"
     ensure -> not? greaterOrEqual? to :word "b" to :type "a"
     ensure -> not? greaterOrEqual? to :word "b" to :type "b"
     passed
@@ -3768,8 +3768,8 @@ do [
     ensure -> not? greaterOrEqual? to :label "b" to :word "b"
     ensure -> not? greaterOrEqual? to :label "b" to :attribute "a"
     ensure -> not? greaterOrEqual? to :label "b" to :attribute "b"
-    ensure -> not? greaterOrEqual? to :label "b" to :attributeLabel "a"
-    ensure -> not? greaterOrEqual? to :label "b" to :attributeLabel "b"
+    ensure -> not? greaterOrEqual? to :label "b" to :attributelabel "a"
+    ensure -> not? greaterOrEqual? to :label "b" to :attributelabel "b"
     ensure -> not? greaterOrEqual? to :label "b" to :type "a"
     ensure -> not? greaterOrEqual? to :label "b" to :type "b"
     passed
@@ -3793,8 +3793,8 @@ do [
     ensure -> not? greaterOrEqual? 'b to :label "b"
     ensure -> not? greaterOrEqual? 'b to :attribute "a"
     ensure -> not? greaterOrEqual? 'b to :attribute "b"
-    ensure -> not? greaterOrEqual? 'b to :attributeLabel "a"
-    ensure -> not? greaterOrEqual? 'b to :attributeLabel "b"
+    ensure -> not? greaterOrEqual? 'b to :attributelabel "a"
+    ensure -> not? greaterOrEqual? 'b to :attributelabel "b"
     ensure -> not? greaterOrEqual? 'b to :type "a"
     ensure -> not? greaterOrEqual? 'b to :type "b"
     passed
@@ -3856,8 +3856,8 @@ do [
     ensure -> not? greaterOrEqual? to :attribute "b" to :word "b"
     ensure -> not? greaterOrEqual? to :attribute "b" to :label "a"
     ensure -> not? greaterOrEqual? to :attribute "b" to :label "b"
-    ensure -> not? greaterOrEqual? to :attribute "b" to :attributeLabel "a"
-    ensure -> not? greaterOrEqual? to :attribute "b" to :attributeLabel "b"
+    ensure -> not? greaterOrEqual? to :attribute "b" to :attributelabel "a"
+    ensure -> not? greaterOrEqual? to :attribute "b" to :attributelabel "b"
     ensure -> not? greaterOrEqual? to :attribute "b" to :type "a"
     ensure -> not? greaterOrEqual? to :attribute "b" to :type "b"
     passed
@@ -4366,7 +4366,7 @@ do [
         -> greaterOrEqual? [:type] [type:]                 -> greaterOrEqual? [:label] [label:]
         -> greaterOrEqual? :1 '1.                          -> greaterOrEqual? :literal '1                       
         -> greaterOrEqual? [:type] [.type]                 -> greaterOrEqual? [:attribute] [.type]              
-        -> greaterOrEqual? [:type] [.type:]                -> greaterOrEqual? [:attributeLabel] [.type:]                
+        -> greaterOrEqual? [:type] [.type:]                -> greaterOrEqual? [:attributelabel] [.type:]                
         -> greaterOrEqual? [:type] [type\type]             -> greaterOrEqual? [:path] [type\type]
         -> greaterOrEqual? [:type] [type\type:]            -> greaterOrEqual? [:pathLabel] [type\type:]            
         -> greaterOrEqual? [:type] [+]                     -> greaterOrEqual? [:symbol] [+]                     
@@ -4467,7 +4467,7 @@ do [
         -> greaterOrEqual? [.var]      @[var 'word?]            -> greaterOrEqual? [.word]     @[var 'word?]
     ] => not? passed
     
-    ; for :attributeLabel
+    ; for :attributelabel
     ensure -> every? @[           
         -> greaterOrEqual? [.rational:] @[to :rational [1 1]]    -> greaterOrEqual? [.null:]     @[null]                  
         -> greaterOrEqual? [.true:]     @[true]                  -> greaterOrEqual? [.false:]    @[false]                 
@@ -4936,7 +4936,7 @@ do [
     ensure -> not? less? "a" to :word "b"
     ensure -> not? less? "a" to :label "b"
     ensure -> not? less? "a" to :attribute "b"
-    ensure -> not? less? "a" to :attributeLabel "b"
+    ensure -> not? less? "a" to :attributelabel "b"
     ensure -> not? less? "a" to :type "b"
     passed
     
@@ -4953,7 +4953,7 @@ do [
     ensure -> not? less? to :word "a" 'b
     ensure -> not? less? to :word "a" to :label "b"
     ensure -> not? less? to :word "a" to :attribute "b"
-    ensure -> not? less? to :word "a" to :attributeLabel "b"
+    ensure -> not? less? to :word "a" to :attributelabel "b"
     ensure -> not? less? to :word "word" to :type "z"
     passed
     
@@ -4971,7 +4971,7 @@ do [
     ensure -> not? less? to :label "a" 'b
     ensure -> not? less? to :label "a" to :word "b"
     ensure -> not? less? to :label "a" to :attribute "b"
-    ensure -> not? less? to :label "a" to :attributeLabel "b"
+    ensure -> not? less? to :label "a" to :attributelabel "b"
     ensure -> not? less? to :label "a" to :type "b"
     passed
     
@@ -4989,7 +4989,7 @@ do [
     ensure -> not? less? 'a to :word "b"
     ensure -> not? less? 'a to :label "b"
     ensure -> not? less? 'a to :attribute "b"
-    ensure -> not? less? 'a to :attributeLabel "b"
+    ensure -> not? less? 'a to :attributelabel "b"
     ensure -> not? less? 'a to :type "b"
     passed
     
@@ -5042,7 +5042,7 @@ do [
     ensure -> not? less? to :attribute "a" 'b
     ensure -> not? less? to :attribute "a" to :word "b"
     ensure -> not? less? to :attribute "a" to :label "b"
-    ensure -> not? less? to :attribute "a" to :attributeLabel "b"
+    ensure -> not? less? to :attribute "a" to :attributelabel "b"
     ensure -> not? less? to :attribute "a" to :type "b"
     passed
     
@@ -5542,7 +5542,7 @@ do [
         -> less? [:type] [type:]                 -> less? [:label] [label:]
         -> less? :1 '1.                          -> less? :literal '1                       
         -> less? [:type] [.type]                 -> less? [:attribute] [.type]              
-        -> less? [:type] [.type:]                -> less? [:attributeLabel] [.type:]                
+        -> less? [:type] [.type:]                -> less? [:attributelabel] [.type:]                
         -> less? [:type] [type\type]             -> less? [:path] [type\type]
         -> less? [:type] [type\type:]            -> less? [:pathLabel] [type\type:]            
         -> less? [:type] [+]                     -> less? [:symbol] [+]                     
@@ -5643,7 +5643,7 @@ do [
         -> less? [.var]      @[var 'word?]            -> less? [.word]     @[var 'word?]
     ] => not? passed
     
-    ; for :attributeLabel
+    ; for :attributelabel
     ensure -> every? @[           
         -> less? [.rational:] @[to :rational [1 1]]    -> less? [.null:]     @[null]                  
         -> less? [.true:]     @[true]                  -> less? [.false:]    @[false]                 
@@ -6113,8 +6113,8 @@ do [
     ensure -> not? lessOrEqual? "a" to :label "b"
     ensure -> not? lessOrEqual? "a" to :attribute "a"
     ensure -> not? lessOrEqual? "a" to :attribute "b"
-    ensure -> not? lessOrEqual? "a" to :attributeLabel "a"
-    ensure -> not? lessOrEqual? "a" to :attributeLabel "b"
+    ensure -> not? lessOrEqual? "a" to :attributelabel "a"
+    ensure -> not? lessOrEqual? "a" to :attributelabel "b"
     ensure -> not? lessOrEqual? "a" to :type "a"
     ensure -> not? lessOrEqual? "a" to :type "b"
     passed
@@ -6138,8 +6138,8 @@ do [
     ensure -> not? lessOrEqual? to :word "a" to :label "b"
     ensure -> not? lessOrEqual? to :word "a" to :attribute "a"
     ensure -> not? lessOrEqual? to :word "a" to :attribute "b"
-    ensure -> not? lessOrEqual? to :word "a" to :attributeLabel "a"
-    ensure -> not? lessOrEqual? to :word "a" to :attributeLabel "b"
+    ensure -> not? lessOrEqual? to :word "a" to :attributelabel "a"
+    ensure -> not? lessOrEqual? to :word "a" to :attributelabel "b"
     ensure -> not? lessOrEqual? to :word "a" to :type "a"
     ensure -> not? lessOrEqual? to :word "a" to :type "b"
     passed
@@ -6163,8 +6163,8 @@ do [
     ensure -> not? lessOrEqual? to :label "a" to :word "b"
     ensure -> not? lessOrEqual? to :label "a" to :attribute "a"
     ensure -> not? lessOrEqual? to :label "a" to :attribute "b"
-    ensure -> not? lessOrEqual? to :label "a" to :attributeLabel "a"
-    ensure -> not? lessOrEqual? to :label "a" to :attributeLabel "b"
+    ensure -> not? lessOrEqual? to :label "a" to :attributelabel "a"
+    ensure -> not? lessOrEqual? to :label "a" to :attributelabel "b"
     ensure -> not? lessOrEqual? to :label "a" to :type "a"
     ensure -> not? lessOrEqual? to :label "a" to :type "b"
     passed
@@ -6188,8 +6188,8 @@ do [
     ensure -> not? lessOrEqual? 'a to :label "b"
     ensure -> not? lessOrEqual? 'a to :attribute "a"
     ensure -> not? lessOrEqual? 'a to :attribute "b"
-    ensure -> not? lessOrEqual? 'a to :attributeLabel "a"
-    ensure -> not? lessOrEqual? 'a to :attributeLabel "b"
+    ensure -> not? lessOrEqual? 'a to :attributelabel "a"
+    ensure -> not? lessOrEqual? 'a to :attributelabel "b"
     ensure -> not? lessOrEqual? 'a to :type "a"
     ensure -> not? lessOrEqual? 'a to :type "b"
     passed
@@ -6251,8 +6251,8 @@ do [
     ensure -> not? lessOrEqual? to :attribute "a" to :word "b"
     ensure -> not? lessOrEqual? to :attribute "a" to :label "a"
     ensure -> not? lessOrEqual? to :attribute "a" to :label "b"
-    ensure -> not? lessOrEqual? to :attribute "a" to :attributeLabel "a"
-    ensure -> not? lessOrEqual? to :attribute "a" to :attributeLabel "b"
+    ensure -> not? lessOrEqual? to :attribute "a" to :attributelabel "a"
+    ensure -> not? lessOrEqual? to :attribute "a" to :attributelabel "b"
     ensure -> not? lessOrEqual? to :attribute "a" to :type "a"
     ensure -> not? lessOrEqual? to :attribute "a" to :type "b"
     passed
@@ -6760,7 +6760,7 @@ do [
         -> lessOrEqual? [:type] [type:]                 -> lessOrEqual? [:label] [label:]
         -> lessOrEqual? :1 '1.                          -> lessOrEqual? :literal '1                       
         -> lessOrEqual? [:type] [.type]                 -> lessOrEqual? [:attribute] [.type]              
-        -> lessOrEqual? [:type] [.type:]                -> lessOrEqual? [:attributeLabel] [.type:]                
+        -> lessOrEqual? [:type] [.type:]                -> lessOrEqual? [:attributelabel] [.type:]                
         -> lessOrEqual? [:type] [type\type]             -> lessOrEqual? [:path] [type\type]
         -> lessOrEqual? [:type] [type\type:]            -> lessOrEqual? [:pathLabel] [type\type:]            
         -> lessOrEqual? [:type] [+]                     -> lessOrEqual? [:symbol] [+]                     
@@ -6861,7 +6861,7 @@ do [
         -> lessOrEqual? [.var]      @[var 'word?]            -> lessOrEqual? [.word]     @[var 'word?]
     ] => not? passed
     
-    ; for :attributeLabel
+    ; for :attributelabel
     ensure -> every? @[           
         -> lessOrEqual? [.rational:] @[to :rational [1 1]]    -> lessOrEqual? [.null:]     @[null]                  
         -> lessOrEqual? [.true:]     @[true]                  -> lessOrEqual? [.false:]    @[false]                 
@@ -7242,7 +7242,7 @@ do [
     ensure -> notEqual? "b" 'a
     ensure -> notEqual? "b" to :label "a"
     ensure -> notEqual? "b" to :attribute "a"
-    ensure -> notEqual? "b" to :attributeLabel "a"
+    ensure -> notEqual? "b" to :attributelabel "a"
     ensure -> notEqual? "text" to :type "string"
     passed
     
@@ -7258,7 +7258,7 @@ do [
     ensure -> notEqual? to :word "b" 'a
     ensure -> notEqual? to :word "b" to :label "a"
     ensure -> notEqual? to :word "b" to :attribute "a"
-    ensure -> notEqual? to :word "b" to :attributeLabel "a"
+    ensure -> notEqual? to :word "b" to :attributelabel "a"
     ensure -> notEqual? to :word "text" to :type "word"
     passed
     
@@ -7286,7 +7286,7 @@ do [
     ensure -> notEqual? 'b to :label "a"
     ensure -> notEqual? 'b to :word "a"
     ensure -> notEqual? 'b to :attribute "a"
-    ensure -> notEqual? 'b to :attributeLabel "a"
+    ensure -> notEqual? 'b to :attributelabel "a"
     ensure -> notEqual? to :literal "text" to :type "literal"
     passed
     
@@ -7302,7 +7302,7 @@ do [
     ensure -> notEqual? to :attribute "b" 'a
     ensure -> notEqual? to :attribute "b" to :word "a"
     ensure -> notEqual? to :attribute "b" to :label "a"
-    ensure -> notEqual? to :attribute "b" to :attributeLabel "a"
+    ensure -> notEqual? to :attribute "b" to :attributelabel "a"
     ensure -> notEqual? to :attribute "text" to :type "label"
     passed
     
@@ -7842,7 +7842,7 @@ do [
         -> notEqual? [:type] [type:]                   -> notEqual? [:label] [label:]
         -> notEqual? :1 '1                             -> notEqual? :literal '1                       
         -> notEqual? [:type] [.type]                   -> notEqual? [:attribute] [.type]              
-        -> notEqual? [:type] [.type:]                  -> notEqual? [:attributeLabel] [.type:]             
+        -> notEqual? [:type] [.type:]                  -> notEqual? [:attributelabel] [.type:]             
         -> notEqual? [:type] [type\type]               -> notEqual? [:path] [type\type]
         -> notEqual? [:type] [type\type:]              -> notEqual? [:pathLabel] [type\type:]            
         -> notEqual? [:type] [+]                       -> notEqual? [:symbol] [+]                     
@@ -7945,7 +7945,7 @@ do [
         -> notEqual? [.var]      @[var 'word?]              -> notEqual? [.word]     @[var 'word?]
     ] => not? passed
     
-    ; for :attributeLabel
+    ; for :attributelabel
     ensure -> not? every? @[           
         -> notEqual? [.rational:] @[to :rational [1 1]]    -> notEqual? [.null:]     @[null]                  
         -> notEqual? [.true:]     @[true]                  -> notEqual? [.false:]    @[false]                 
@@ -8359,7 +8359,7 @@ do [
     passed
     
     
-    topic « same? - :attributeLabel
+    topic « same? - :attributelabel
     
     ensure -> same? [.attr: value] [.attr: value]
     passed
@@ -8903,7 +8903,7 @@ do [
         -> same? [:type] [type:]                -> same? [:label] [label:]
         -> same? :1 '1                          -> same? :literal '1                       
         -> same? [:type] [.type]                -> same? [:attribute] [.type]              
-        -> same? [:type] [.type:]               -> same? [:attributeLabel] [.type:]                
+        -> same? [:type] [.type:]               -> same? [:attributelabel] [.type:]                
         -> same? [:type] [type\type]            -> same? [:path] [type\type]
         -> same? [:type] [type\type:]           -> same? [:pathLabel] [type\type:]            
         -> same? [:type] [+]                    -> same? [:symbol] [+]                     
@@ -9005,7 +9005,7 @@ do [
         -> same? [.var]      @[var 'word?]            -> same? [.word]     @[var 'word?]
     ] => not? passed
     
-    ; for :attributeLabel
+    ; for :attributelabel
     ensure -> every? @[           
         -> same? [.rational:] @[to :rational [1 1]]    -> same? [.null:]     @[null]                  
         -> same? [.true:]     @[true]                  -> same? [.false:]    @[false]                 

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -5055,30 +5055,21 @@ do [
     passed
     
     
-    topic « less? - :attributeLabel
+    topic « less? - :attributelabel
     
-    ensure -> not? less? [.attr: value] [.attr: value]
+    ; ensure -> less? to :attributelabel "a" to :attributelabel "b"
+    ensure -> not? less? to :attributelabel "a" to :attributelabel "a"
+    ensure -> not? less? to :attributelabel "b" to :attributelabel "b"
+    ensure -> not? less? to :attributelabel "b" to :attributelabel "a"
     passed
     
-    ensure -> not? less? [.attr:] ["attr"]
-    ensure -> not? less? [.attr:] ["value"]
-    ensure -> not? less? [.attr: value] ["attr" "value"]
-    passed
-    
-    ensure -> not? less? [.attr:] [attr]
-    ensure -> not? less? [.attr: value] [attr: .attr:]
-    ensure -> not? less? [.attr: value] [attr: value]
-    passed
-    
-    ensure -> not? less? [.attr:] ['attr]
-    ensure -> not? less? [.attr:] ['value]
-    ensure -> not? less? [.attr: value] ['attr 'value]
-    passed
-    
-    ensure -> not? less? [.attr:] [.attr]
-    ensure -> not? less? [.attr:] [.value]
-    ensure -> not? less? [.attr: value] [.other: value]
-    ensure -> not? less? [.attr: value] [.attr: other]
+    ensure -> not? less? to :attributelabel "a" "b"
+    ensure -> not? less? to :attributelabel "a" `b`
+    ensure -> not? less? to :attributelabel "a" 'b
+    ensure -> not? less? to :attributelabel "a" to :word "b"
+    ensure -> not? less? to :attributelabel "a" to :label "b"
+    ensure -> not? less? to :attributelabel "a" to :attribute "b"
+    ensure -> not? less? to :attributelabel "a" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -3838,11 +3838,26 @@ do [
     
     topic « greaterOrEqual? - :attribute
     
-    ensure -> greaterOrEqual? [.attr] [.attr]
-    ensure -> not? greaterOrEqual? [.attr] ["attr"]
-    ; ensure -> not? greaterOrEqual? [.attr] [attr]
-    ensure -> not? greaterOrEqual? [.attr] ['attr]
-    ensure -> not? greaterOrEqual? [.attr] [.other]
+    ; ensure -> greaterOrEqual? to :attribute "b" to :attribute "a"
+    ensure -> greaterOrEqual? to :attribute "a" to :attribute "a"
+    ensure -> greaterOrEqual? to :attribute "b" to :attribute "b"
+    ensure -> not? greaterOrEqual? to :attribute "a" to :attribute "b"
+    passed
+    
+    ensure -> not? greaterOrEqual? to :attribute "b" "a"
+    ensure -> not? greaterOrEqual? to :attribute "b" "b"
+    ensure -> not? greaterOrEqual? to :attribute "b" `a`
+    ensure -> not? greaterOrEqual? to :attribute "b" `b`
+    ensure -> not? greaterOrEqual? to :attribute "b" 'a
+    ensure -> not? greaterOrEqual? to :attribute "b" 'b
+    ensure -> not? greaterOrEqual? to :attribute "b" to :word "a"
+    ensure -> not? greaterOrEqual? to :attribute "b" to :word "b"
+    ensure -> not? greaterOrEqual? to :attribute "b" to :label "a"
+    ensure -> not? greaterOrEqual? to :attribute "b" to :label "b"
+    ensure -> not? greaterOrEqual? to :attribute "b" to :attributeLabel "a"
+    ensure -> not? greaterOrEqual? to :attribute "b" to :attributeLabel "b"
+    ensure -> not? greaterOrEqual? to :attribute "b" to :type "a"
+    ensure -> not? greaterOrEqual? to :attribute "b" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -3888,14 +3888,14 @@ do [
     
     topic « greaterOrEqual? - :symbol
     
-    ensure -> greaterOrEqual? [+] [+]
-    ensure -> not? greaterOrEqual? [+] [-]
-    ensure -> not? greaterOrEqual? [+] [++]
-    ensure -> not? greaterOrEqual? [+] [`+`]
-    ensure -> not? greaterOrEqual? [+] [{+}]
-    ensure -> not? greaterOrEqual? [+] ["+"]
-    ensure -> not? greaterOrEqual? [+] [plus]
-    ensure -> not? greaterOrEqual? [+] ['+]
+    ensure -> greaterOrEqual? to :symbol "+" to :symbol "+"
+    ensure -> not? greaterOrEqual? to :symbol "+" to :symbol "-"
+    ensure -> not? greaterOrEqual? to :symbol "+" to :symbol "++"
+    ensure -> not? greaterOrEqual? to :symbol "+" `+`
+    ensure -> not? greaterOrEqual? to :symbol "+" {+}
+    ensure -> not? greaterOrEqual? to :symbol "+" "+"
+    ensure -> not? greaterOrEqual? to :symbol "+" to :word "plus"
+    ensure -> not? greaterOrEqual? to :symbol "+" '+
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -7261,13 +7261,13 @@ do [
     ensure -> not? notEqual? to :word "a" to :word "a"
     passed
     
-    ensure -> notEqual? to :word "a" "a"
-    ensure -> notEqual? to :word "a" `a`
-    ensure -> notEqual? to :word "a" 'a
-    ensure -> notEqual? to :word "a" to :label "a"
-    ensure -> notEqual? to :word "a" to :attribute "a"
-    ensure -> notEqual? to :word "a" to :attributeLabel "a"
-    ensure -> notEqual? to :word "word" to :type "word"
+    ensure -> notEqual? to :word "b" "a"
+    ensure -> notEqual? to :word "b" `a`
+    ensure -> notEqual? to :word "b" 'a
+    ensure -> notEqual? to :word "b" to :label "a"
+    ensure -> notEqual? to :word "b" to :attribute "a"
+    ensure -> notEqual? to :word "b" to :attributeLabel "a"
+    ensure -> notEqual? to :word "text" to :type "word"
     passed
     
     
@@ -7277,13 +7277,13 @@ do [
     ensure -> not? notEqual? to :label "a" to :label "a"
     passed
     
-    ensure -> notEqual? to :label "a" "a"
-    ensure -> notEqual? to :label "a" `a`
-    ensure -> notEqual? to :label "a" 'a
-    ensure -> notEqual? to :label "a" to :word "a"
-    ensure -> notEqual? to :label "a" to :attribute "a"
-    ensure -> notEqual? to :label "a" to :attributelabel "a"
-    ensure -> notEqual? to :label "label" to :type "label"
+    ensure -> notEqual? to :label "b" "a"
+    ensure -> notEqual? to :label "b" `a`
+    ensure -> notEqual? to :label "b" 'a
+    ensure -> notEqual? to :label "b" to :word "a"
+    ensure -> notEqual? to :label "b" to :attribute "a"
+    ensure -> notEqual? to :label "b" to :attributelabel "a"
+    ensure -> notEqual? to :label "text" to :type "label"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -5039,11 +5039,19 @@ do [
     
     topic « less? - :attribute
     
-    ensure -> not? less? [.attr] [.attr]
-    ensure -> not? less? [.attr] ["attr"]
-    ensure -> not? less? [.attr] [attr]
-    ensure -> not? less? [.attr] ['attr]
-    ensure -> not? less? [.attr] [.other]
+    ; ensure -> less? to :attribute "a" to :attribute "b"
+    ensure -> not? less? to :attribute "a" to :attribute "a"
+    ensure -> not? less? to :attribute "b" to :attribute "b"
+    ensure -> not? greaterOrEqual? to :attribute "b" to :attribute "a"
+    passed
+    
+    ensure -> not? less? to :attribute "a" "b"
+    ensure -> not? less? to :attribute "a" `b`
+    ensure -> not? less? to :attribute "a" 'b
+    ensure -> not? less? to :attribute "a" to :word "b"
+    ensure -> not? less? to :attribute "a" to :label "b"
+    ensure -> not? less? to :attribute "a" to :attributeLabel "b"
+    ensure -> not? less? to :attribute "a" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -897,12 +897,10 @@ do [
     
     topic « compare - :label
     
-    a: [a:] b: [b:]
-    
-    ensure -> 0 = compare a\0 a\0
-    ensure -> 0 = compare b\0 b\0
-    ensure -> (neg 1) = compare a\0 b\0 
-    ensure -> 1 = compare b\0 a\0
+    ensure -> 1 = compare to :label "b" to :label "a"
+    ensure -> 0 = compare to :label "a" to :label "a"
+    ensure -> 0 = compare to :label "b" to :label "b"
+    ensure -> (neg 1) = compare to :label "a" to :label "b"
     passed
 
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -8321,13 +8321,17 @@ do [
     
     topic « same? - :literal
     
-    ensure -> same? 'literal 'literal
-    ensure -> not? same? 'literal 'other
-    ensure -> not? same? 'literal "literal"
-    ensure -> not? same? ['literal] ["literal"]
-    ensure -> not? same? ['literal] [literal]
-    ensure -> not? same? ['literal] [.literal]
-    ensure -> not? same? ['literal] [literal: 'literal]
+    ensure -> same? 'a 'a
+    ensure -> not? same? 'a 'b
+    passed
+    
+    ensure -> not? same? 'a "a"
+    ensure -> not? same? 'a `a`
+    ensure -> not? same? 'a to :label "a"
+    ensure -> not? same? 'a to :word "a"
+    ensure -> not? same? 'a to :attribute "a"
+    ensure -> not? same? 'a to :attributelabel "a"
+    ensure -> not? same? to :literal "literal" to :type "literal"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -8402,14 +8402,14 @@ do [
     
     topic « same? - :symbol
     
-    ensure -> same? [+] [+]
-    ensure -> not? same? [+] [-]
-    ensure -> not? same? [+] [++]
-    ensure -> not? same? [+] [`+`]
-    ensure -> not? same? [+] [{+}]
-    ensure -> not? same? [+] ["+"]
-    ensure -> not? same? [+] [plus]
-    ensure -> not? same? [+] ['+]
+    ensure -> same? to :symbol "+" to :symbol "+"
+    ensure -> not? same? to :symbol "+" to :symbol "-"
+    ensure -> not? same? to :symbol "+" "++"
+    ensure -> not? same? to :symbol "+" `+`
+    ensure -> not? same? to :symbol "+" {+}
+    ensure -> not? same? to :symbol "+" "+"
+    ensure -> not? same? to :symbol "+" to :word "plus"
+    ensure -> not? same? to :symbol "+" '+
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -8278,14 +8278,12 @@ do [
     ensure -> not? same? "Art" "Bob"
     passed
     
-    ensure -> not? same? "a"    `a` 
-    ensure -> not? same? "10"   10 
-    ensure -> not? same? "10"   10
-    ensure -> not? same? ["help"] [help]
-    ensure -> not? same? ["a"]    [a: "a"]
-    ensure -> not? same? "help"   'help
-    ensure -> not? same? ["help"] [.help]
-    ensure -> not? same? ["help"] ['help: "help"]
+    ensure -> not? same? "a" `a`
+    ensure -> not? same? "a" 'a
+    ensure -> not? same? "a" to :label "a"
+    ensure -> not? same? "a" to :attribute "a"
+    ensure -> not? same? "a" to :attributelabel "a"
+    ensure -> not? same? "string" to :type "string"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -914,12 +914,10 @@ do [
     
     topic « compare - :attribute
     
-    a: [.attr], b: [.other]
-    
-    ensure -> 0 = compare a\0 a\0
-    ensure -> 0 = compare b\0 b\0
-    ; ensure -> (neg 1) = compare a\0 b\0 
-    ensure -> 1 = compare b\0 a\0
+    ensure -> 1 = compare to :attribute "b" to :attribute "a"
+    ensure -> 0 = compare to :attribute "a" to :attribute "a"
+    ensure -> 0 = compare to :attribute "b" to :attribute "b"
+    ; ensure -> (neg 1) = compare to :attribute "a" to :attribute "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2586,15 +2586,18 @@ do [
     
     topic « greater? - :literal
     
-    ensure -> not? greater? 'a 'b
     ensure -> greater? 'b 'a
-    ensure -> not? greater? 'literal 'literal
-    ensure -> greater? 'other 'literal
-    ensure -> not? greater? 'literal "literal"
-    ensure -> not? greater? ['literal] ["literal"]
-    ensure -> not? greater? ['literal] [literal]
-    ensure -> not? greater? ['literal] [.literal]
-    ensure -> not? greater? ['literal] [literal:]
+    ensure -> not? greater? 'a 'a
+    ensure -> not? greater? 'a 'b
+    passed
+    
+    ensure -> not? greater? 'a "a"
+    ensure -> not? greater? 'a `a`
+    ensure -> not? greater? 'a to :word "a"
+    ensure -> not? greater? 'a to :label "a"
+    ensure -> not? greater? 'a to :attribute "a"
+    ensure -> not? greater? 'a to :attributeLabel "a"
+    ensure -> not? greater? 'word to :type "word"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -3736,17 +3736,26 @@ do [
     
     topic « greaterOrEqual? - :word
     
-    ensure -> not? greaterOrEqual? [a] [b]
-    a: [a]
-    b: [b]
-    ensure -> greaterOrEqual? b\0 a\0
-    ensure -> greaterOrEqual? [word] [word]
-    ; ensure -> greaterOrEqual? [word] [otherWord]
-    ensure -> not? greaterOrEqual? [word] ["word"]
-    ; ensure -> not? greaterOrEqual? [word] [word:]
-    ensure -> not? greaterOrEqual? [word] ['word]
-    ; ensure -> not? greaterOrEqual? [word] [.word]
-    ; ensure -> not? greaterOrEqual? [word] [.word:]
+    ensure -> greaterOrEqual? to :word "b" to :word "a"
+    ensure -> greaterOrEqual? to :word "a" to :word "a"
+    ensure -> greaterOrEqual? to :word "b" to :word "b"
+    ensure -> not? greaterOrEqual? to :word "a" to :word "b"
+    passed
+    
+    ensure -> not? greaterOrEqual? to :word "b" "a"
+    ensure -> not? greaterOrEqual? to :word "b" "b"
+    ensure -> not? greaterOrEqual? to :word "b" `a`
+    ensure -> not? greaterOrEqual? to :word "b" `b`
+    ensure -> not? greaterOrEqual? to :word "b" 'a
+    ensure -> not? greaterOrEqual? to :word "b" 'b
+    ensure -> not? greaterOrEqual? to :word "b" to :label "a"
+    ensure -> not? greaterOrEqual? to :word "b" to :label "b"
+    ensure -> not? greaterOrEqual? to :word "b" to :attribute "a"
+    ensure -> not? greaterOrEqual? to :word "b" to :attribute "b"
+    ensure -> not? greaterOrEqual? to :word "b" to :attributeLabel "a"
+    ensure -> not? greaterOrEqual? to :word "b" to :attributeLabel "b"
+    ensure -> not? greaterOrEqual? to :word "b" to :type "a"
+    ensure -> not? greaterOrEqual? to :word "b" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -7301,19 +7301,17 @@ do [
     
     topic « notEqual? - :attribute
     
-    ensure -> not? notEqual? [.attr] [.attr]
-    ensure -> notEqual? [.attr] ["attr"]
-    ; ensure -> notEqual? [.attr] [attr]
-    ensure -> notEqual? [.attr] [attr: .attr]
-    ensure -> notEqual? [.attr] ['attr]
-    ensure -> notEqual? [.attr] [.other]
-    ensure -> notEqual? [.attr] [.attr: .attr]
+    ensure -> notEqual? to :attribute "a" to :attribute "b"
+    ensure -> not? notEqual? to :attribute "a" to :attribute "a"
     passed
     
-    
-    topic « notEqual? - :attributeLabel
-    
-    ensure -> not? notEqual? [.attr: value] [.attr: value]
+    ensure -> notEqual? to :attribute "b" "a"
+    ensure -> notEqual? to :attribute "b" `a`
+    ensure -> notEqual? to :attribute "b" 'a
+    ensure -> notEqual? to :attribute "b" to :word "a"
+    ensure -> notEqual? to :attribute "b" to :label "a"
+    ensure -> notEqual? to :attribute "b" to :attributeLabel "a"
+    ensure -> notEqual? to :attribute "text" to :type "label"
     passed
     
     ensure -> notEqual? [.attr: value] ["attr"]

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2574,7 +2574,7 @@ do [
     ensure -> not? greater? to :label "a" to :word "a"
     ensure -> not? greater? to :label "a" to :attribute "a"
     ensure -> not? greater? to :label "a" to :attributeLabel "a"
-    ensure -> not? greater? to :label "word" to :type "word"
+    ensure -> not? greater? to :label "label" to :type "label"
     passed
     
     
@@ -2591,7 +2591,7 @@ do [
     ensure -> not? greater? 'a to :label "a"
     ensure -> not? greater? 'a to :attribute "a"
     ensure -> not? greater? 'a to :attributeLabel "a"
-    ensure -> not? greater? 'word to :type "word"
+    ensure -> not? greater? 'literal to :type "literal"
     passed
     
     
@@ -2646,7 +2646,7 @@ do [
     ensure -> not? greater? to :attribute "a" to :word "a"
     ensure -> not? greater? to :attribute "a" to :label "a"
     ensure -> not? greater? to :attribute "a" to :attributeLabel "a"
-    ensure -> not? greater? to :attribute "word" to :type "word"
+    ensure -> not? greater? to :attribute "attribute" to :type "attribute"
     passed
 
     
@@ -2663,7 +2663,8 @@ do [
     ensure -> not? greater? to :attributeLabel "a" to :word "a"
     ensure -> not? greater? to :attributeLabel "a" to :label "a"
     ensure -> not? greater? to :attributeLabel "a" to :attribute "a"
-    ensure -> not? greater? to :attributeLabel "word" to :type "word"
+    ensure -> not? greater? to :attributeLabel "attributeLabel" 
+                            to :type "attributeLabel"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -3786,15 +3786,26 @@ do [
     
     topic « greaterOrEqual? - :literal
     
-    ensure -> not? greaterOrEqual? 'a 'b
     ensure -> greaterOrEqual? 'b 'a
-    ensure -> greaterOrEqual? 'literal 'literal
-    ensure -> greaterOrEqual? 'other 'literal
-    ensure -> not? greaterOrEqual? 'literal "literal"
-    ensure -> not? greaterOrEqual? ['literal] ["literal"]
-    ensure -> not? greaterOrEqual? ['literal] [literal]
-    ensure -> not? greaterOrEqual? ['literal] [.literal]
-    ensure -> not? greaterOrEqual? ['literal] [literal:]
+    ensure -> greaterOrEqual? 'a 'a
+    ensure -> greaterOrEqual? 'b 'b
+    ensure -> not? greaterOrEqual? 'a 'b
+    passed
+    
+    ensure -> not? greaterOrEqual? 'b "a"
+    ensure -> not? greaterOrEqual? 'b "b"
+    ensure -> not? greaterOrEqual? 'b `a`
+    ensure -> not? greaterOrEqual? 'b `b`
+    ensure -> not? greaterOrEqual? 'b to :word "a"
+    ensure -> not? greaterOrEqual? 'b to :word "b"
+    ensure -> not? greaterOrEqual? 'b to :label "a"
+    ensure -> not? greaterOrEqual? 'b to :label "b"
+    ensure -> not? greaterOrEqual? 'b to :attribute "a"
+    ensure -> not? greaterOrEqual? 'b to :attribute "b"
+    ensure -> not? greaterOrEqual? 'b to :attributeLabel "a"
+    ensure -> not? greaterOrEqual? 'b to :attributeLabel "b"
+    ensure -> not? greaterOrEqual? 'b to :type "a"
+    ensure -> not? greaterOrEqual? 'b to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -6293,14 +6293,14 @@ do [
     
     topic « lessOrEqual? - :symbol
     
-    ensure -> lessOrEqual? [+] [+]
-    ensure -> not? lessOrEqual? [+] [-]
-    ensure -> not? lessOrEqual? [+] [++]
-    ensure -> not? lessOrEqual? [+] [`+`]
-    ensure -> not? lessOrEqual? [+] [{+}]
-    ensure -> not? lessOrEqual? [+] ["+"]
-    ensure -> not? lessOrEqual? [+] [plus]
-    ensure -> not? lessOrEqual? [+] ['+]
+    ensure -> lessOrEqual? to :symbol "+" to :symbol "+"
+    ensure -> not? lessOrEqual? to :symbol "+" to :symbol "-"
+    ensure -> not? lessOrEqual? to :symbol "+" to :symbol "++"
+    ensure -> not? lessOrEqual? to :symbol "+" `+`
+    ensure -> not? lessOrEqual? to :symbol "+" {+}
+    ensure -> not? lessOrEqual? to :symbol "+" "+"
+    ensure -> not? lessOrEqual? to :symbol "+" to :word "plus"
+    ensure -> not? lessOrEqual? to :symbol "+" '+
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -8305,35 +8305,17 @@ do [
     
     topic « same? - :label
     
-    ensure -> same? [label: value] [label: value]
+    ensure -> same? to :label "a" to :label "a"
+    ensure -> not? same? to :label "a" to :label "b"
     passed
     
-    ensure -> not? same? [label: value] [label: value2]
-    ensure -> not? same? [label: value] [label2: value]
-    passed
-    
-    ensure -> not? same? [label: value] ["label"]
-    ensure -> not? same? ["label": value] ["label"]
-    ensure -> not? same? [label: value] ["value"]
-    ensure -> not? same? [label: "value"] ["value"]
-    ensure -> not? same? [label: "value"] ["label" "value"]
-    passed
-    
-    ensure -> not? same? [label: "value"] [label]
-    ensure -> not? same? [label: "value"] [value]
-    ensure -> not? same? [label: "value"] [label value]
-    passed
-    
-    ensure -> not? same? [label: 'world] ['label]
-    ensure -> not? same? [label: 'world] ['word]
-    ensure -> not? same? [label: 'world] ['label 'word]
-    passed
-    
-    ensure -> not? same? [label: .attr] [.label]
-    ensure -> not? same? [label: .attr] [.attr]
-    ; ensure -> not? same? [label: .attr: "a"] [.label: .attr: "a"]
-    ensure -> not? same? [label: .attr: "a"] [.label: "a"]
-    ensure -> not? same? [label: .attr: "a"] [.attr: "a"]
+    ensure -> not? same? to :label "a" "a"
+    ensure -> not? same? to :label "a" `a`
+    ensure -> not? same? to :label "a" 'a
+    ensure -> not? same? to :label "a" to :word "a"
+    ensure -> not? same? to :label "a" to :attribute "a"
+    ensure -> not? same? to :label "a" to :attributelabel "a"
+    ensure -> not? same? to :label "label" to :type "label"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2552,17 +2552,18 @@ do [
     
     topic « greater? - :word
     
-    ensure -> not? greater? [a] [b]
-    a: [a]
-    b: [b]
-    ensure -> greater? b\0 a\0
-    ; ensure -> greater? [word] [otherWord]
-    ensure -> not? greater? [word] [word]
-    ensure -> not? greater? [word] ["word"]
-    ; ensure -> not? greater? [word] [word:]
-    ensure -> not? greater? [word] ['word]
-    ; ensure -> not? greater? [word] [.word]
-    ; ensure -> not? greater? [word] [.word:]
+    ensure -> greater? to :word "b" to :word "a"
+    ensure -> not? greater? to :word "a" to :word "a"
+    ensure -> not? greater? to :word "a" to :word "b"
+    passed
+    
+    ensure -> not? greater? to :word "a" "a"
+    ensure -> not? greater? to :word "a" `a`
+    ensure -> not? greater? to :word "a" 'a
+    ensure -> not? greater? to :word "a" to :label "a"
+    ensure -> not? greater? to :word "a" to :attribute "a"
+    ensure -> not? greater? to :word "a" to :attributeLabel "a"
+    ensure -> not? greater? to :word "word" to :type "word"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -6130,17 +6130,26 @@ do [
     
     topic « lessOrEqual? - :word
     
-    ; ensure -> lessOrEqual? [a] [b]
-    a: [a]
-    b: [b]
-    ensure -> lessOrEqual? a\0 b\0
-    ensure -> lessOrEqual? [word] [word]
-    ensure -> not? lessOrEqual? [word] [otherWord]
-    ensure -> not? lessOrEqual? [word] ["word"]
-    ; ensure -> not? lessOrEqual? [word] [word:]
-    ensure -> not? lessOrEqual? [word] ['word]
-    ; ensure -> not? lessOrEqual? [word] [.word]
-    ; ensure -> not? lessOrEqual? [word] [.word:]
+    ensure -> lessOrEqual? to :word "a" to :word "a"
+    ensure -> lessOrEqual? to :word "b" to :word "b"
+    ensure -> lessOrEqual? to :word "a" to :word "b"
+    ensure -> not? lessOrEqual? to :word "b" to :word "a"
+    passed
+    
+    ensure -> not? lessOrEqual? to :word "a" "a"
+    ensure -> not? lessOrEqual? to :word "a" "b"
+    ensure -> not? lessOrEqual? to :word "a" `a`
+    ensure -> not? lessOrEqual? to :word "a" `b`
+    ensure -> not? lessOrEqual? to :word "a" 'a
+    ensure -> not? lessOrEqual? to :word "a" 'b
+    ensure -> not? lessOrEqual? to :word "a" to :label "a"
+    ensure -> not? lessOrEqual? to :word "a" to :label "b"
+    ensure -> not? lessOrEqual? to :word "a" to :attribute "a"
+    ensure -> not? lessOrEqual? to :word "a" to :attribute "b"
+    ensure -> not? lessOrEqual? to :word "a" to :attributeLabel "a"
+    ensure -> not? lessOrEqual? to :word "a" to :attributeLabel "b"
+    ensure -> not? lessOrEqual? to :word "a" to :type "a"
+    ensure -> not? lessOrEqual? to :word "a" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -7289,13 +7289,13 @@ do [
     
     topic « notEqual? - :literal
     
-    ensure -> not? notEqual? 'literal 'literal
-    ensure -> notEqual? 'literal 'other
-    ensure -> notEqual? 'literal "literal"
-    ensure -> notEqual? ['literal] ["literal"]
-    ensure -> notEqual? ['literal] [literal]
-    ensure -> notEqual? ['literal] [.literal]
-    ensure -> notEqual? ['literal] [literal: 'literal]
+    ensure -> notEqual? 'b "a"
+    ensure -> notEqual? 'b `a`
+    ensure -> notEqual? 'b to :label "a"
+    ensure -> notEqual? 'b to :word "a"
+    ensure -> notEqual? 'b to :attribute "a"
+    ensure -> notEqual? 'b to :attributeLabel "a"
+    ensure -> notEqual? to :literal "text" to :type "literal"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2650,7 +2650,7 @@ do [
     passed
 
     
-    topic « greaterOrEqual? - :attributeLabel
+    topic « greater? - :attributeLabel
     
     ; ensure -> greater? to :attributeLabel "b" to :attributeLabel "a"
     ensure -> not? greater? to :attributeLabel "a" to :attributeLabel "a"
@@ -2819,7 +2819,7 @@ do [
     ensure -> greater? d c
     
     
-    topic « greaterOrEqual? - :store
+    topic « greater? - :store
     
     a: store "test.db"
     a\name: "John" a\surname: "Doe"

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -921,14 +921,12 @@ do [
     passed
     
     
-    topic « compare - :attributeLabel
+    topic « compare - :attributelabel
     
-    a: [.attr:], b: [.other:]
-    
-    ensure -> 0 = compare a\0 a\0
-    ensure -> 0 = compare b\0 b\0
-    ; ensure -> (neg 1) = compare a\0 b\0 
-    ensure -> 1 = compare b\0 a\0
+    ensure -> 1 = compare to :attributelabel "b" to :attributelabel "a"
+    ensure -> 0 = compare to :attributelabel "a" to :attributelabel "a"
+    ensure -> 0 = compare to :attributelabel "b" to :attributelabel "b"
+    ; ensure -> (neg 1) = compare to :attributelabel "a" to :attributelabel "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -7273,35 +7273,17 @@ do [
     
     topic « notEqual? - :label
     
-    ensure -> not? notEqual? [label: value] [label: value]
+    ensure -> notEqual? to :label "a" to :label "b"
+    ensure -> not? notEqual? to :label "a" to :label "a"
     passed
     
-    ensure -> notEqual? [label: value] [label: value2]
-    ensure -> notEqual? [label: value] [label2: value]
-    passed
-    
-    ensure -> notEqual? [label: value] ["label"]
-    ensure -> notEqual? ["label": value] ["label"]
-    ensure -> notEqual? [label: value] ["value"]
-    ensure -> notEqual? [label: "value"] ["value"]
-    ensure -> notEqual? [label: "value"] ["label" "value"]
-    passed
-    
-    ensure -> notEqual? [label: "value"] [label]
-    ensure -> notEqual? [label: "value"] [value]
-    ensure -> notEqual? [label: "value"] [label value]
-    passed
-    
-    ensure -> notEqual? [label: 'world] ['label]
-    ensure -> notEqual? [label: 'world] ['word]
-    ensure -> notEqual? [label: 'world] ['label 'word]
-    passed
-    
-    ensure -> notEqual? [label: .attr] [.label]
-    ensure -> notEqual? [label: .attr] [.attr]
-    ; ensure -> notEqual? [label: .attr: "a"] [.label: .attr: "a"]
-    ensure -> notEqual? [label: .attr: "a"] [.label: "a"]
-    ensure -> notEqual? [label: .attr: "a"] [.attr: "a"]
+    ensure -> notEqual? to :label "a" "a"
+    ensure -> notEqual? to :label "a" `a`
+    ensure -> notEqual? to :label "a" 'a
+    ensure -> notEqual? to :label "a" to :word "a"
+    ensure -> notEqual? to :label "a" to :attribute "a"
+    ensure -> notEqual? to :label "a" to :attributelabel "a"
+    ensure -> notEqual? to :label "label" to :type "label"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2508,6 +2508,7 @@ do [
     
     topic « greater? - :type
     
+    ensure -> not? greater? :a :b
     ensure -> not? greater? :char :char
     ensure -> not? greater? :string type "a"
     ensure -> not? greater? :integer type 1

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -7366,14 +7366,14 @@ do [
     
     topic « notEqual? - :symbol
     
-    ensure -> not? notEqual? [+] [+]
-    ensure -> notEqual? [+] [-]
-    ensure -> notEqual? [+] [++]
-    ensure -> notEqual? [+] [`+`]
-    ensure -> notEqual? [+] [{+}]
-    ensure -> notEqual? [+] ["+"]
-    ensure -> notEqual? [+] [plus]
-    ensure -> notEqual? [+] ['+]
+    ensure -> not? notEqual? to :symbol "+" to :symbol "+"
+    ensure -> notEqual? to :symbol "+" to :symbol "-"
+    ensure -> notEqual? to :symbol "+" "++"
+    ensure -> notEqual? to :symbol "+" `+`
+    ensure -> notEqual? to :symbol "+" {+}
+    ensure -> notEqual? to :symbol "+" "+"
+    ensure -> notEqual? to :symbol "+" to :word "plus"
+    ensure -> notEqual? to :symbol "+" '+
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -6268,29 +6268,26 @@ do [
     
     topic « lessOrEqual? - :attributeLabel
     
-    ensure -> lessOrEqual? [.attr: value] [.attr: value]
+    ; ensure -> lessOrEqual? to :attributelabel "a" to :attributelabel "b"
+    ensure -> lessOrEqual? to :attributelabel "a" to :attributelabel "a"
+    ensure -> lessOrEqual? to :attributelabel "b" to :attributelabel "b"
+    ensure -> not? lessOrEqual? to :attributelabel "b" to :attributelabel "a"
     passed
     
-    ensure -> not? lessOrEqual? [.attr:] ["attr"]
-    ensure -> not? lessOrEqual? [.attr:] ["value"]
-    ensure -> not? lessOrEqual? [.attr: value] ["attr" "value"]
-    passed
-    
-    ; ensure -> not? lessOrEqual? [.attr:] [attr]
-    ensure -> not? lessOrEqual? [.attr: value] [attr: .attr:]
-    ; ensure -> not? lessOrEqual? [.attr: value] [attr: value]
-    ensure -> not? lessOrEqual? [.attr: value] [attr: .attr:]
-    passed
-    
-    ensure -> not? lessOrEqual? [.attr:] ['attr]
-    ensure -> not? lessOrEqual? [.attr:] ['value]
-    ensure -> not? lessOrEqual? [.attr: value] ['attr 'value]
-    passed
-    
-    ; ensure -> not? lessOrEqual? [.attr:] [.attr]
-    ensure -> not? lessOrEqual? [.attr:] [.value]
-    ensure -> not? lessOrEqual? [.attr: value] [.other: value]
-    ensure -> not? lessOrEqual? [.attr: value] [.attr: other]
+    ensure -> not? lessOrEqual? to :attributelabel "a" "a"
+    ensure -> not? lessOrEqual? to :attributelabel "a" "b"
+    ensure -> not? lessOrEqual? to :attributelabel "a" `a`
+    ensure -> not? lessOrEqual? to :attributelabel "a" `b`
+    ensure -> not? lessOrEqual? to :attributelabel "a" 'a
+    ensure -> not? lessOrEqual? to :attributelabel "a" 'b
+    ensure -> not? lessOrEqual? to :attributelabel "a" to :word "a"
+    ensure -> not? lessOrEqual? to :attributelabel "a" to :word "b"
+    ensure -> not? lessOrEqual? to :attributelabel "a" to :label "a"
+    ensure -> not? lessOrEqual? to :attributelabel "a" to :label "b"
+    ensure -> not? lessOrEqual? to :attributelabel "a" to :attribute "a"
+    ensure -> not? lessOrEqual? to :attributelabel "a" to :attribute "b"
+    ensure -> not? lessOrEqual? to :attributelabel "a" to :type "a"
+    ensure -> not? lessOrEqual? to :attributelabel "a" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -8353,29 +8353,17 @@ do [
     
     topic « same? - :attributelabel
     
-    ensure -> same? [.attr: value] [.attr: value]
+    ensure -> same? to :attributelabel "a" to :attributelabel "a"
+    ensure -> not? same? to :attributelabel "a" to :attributelabel "b"
     passed
     
-    ensure -> not? same? [.attr: value] ["attr"]
-    ensure -> not? same? [.attr: value] ["value"]
-    ensure -> not? same? [.attr: value] ["attr" "value"]
-    passed
-    
-    ensure -> not? same? [.attr: value] [attr]
-    ensure -> not? same? [.attr: value] [attr: .attr:]
-    ; ensure -> not? same? [.attr: value] [attr: value]
-    ensure -> not? same? [.attr: value] [attr: .attr: value]
-    passed
-    
-    ensure -> not? same? [.attr: value] ['attr]
-    ensure -> not? same? [.attr: value] ['value]
-    ensure -> not? same? [.attr: value] ['attr 'value]
-    passed
-    
-    ensure -> not? same? [.attr: value] [.attr]
-    ensure -> not? same? [.attr: value] [.value]
-    ensure -> not? same? [.attr: value] [.other: value]
-    ensure -> not? same? [.attr: value] [.attr: other]
+    ensure -> not? same? to :attributelabel "a" "a"
+    ensure -> not? same? to :attributelabel "a" `a`
+    ensure -> not? same? to :attributelabel "a" 'a
+    ensure -> not? same? to :attributelabel "a" to :word "a"
+    ensure -> not? same? to :attributelabel "a" to :label "a"
+    ensure -> not? same? to :attributelabel "a" to :attribute "a"
+    ensure -> not? same? to :attributelabel "label" to :type "label"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -6180,14 +6180,26 @@ do [
     
     topic « lessOrEqual? - :literal
     
+    ensure -> lessOrEqual? 'a 'a
+    ensure -> lessOrEqual? 'b 'b
     ensure -> lessOrEqual? 'a 'b
-    ensure -> lessOrEqual? 'literal 'literal
-    ensure -> lessOrEqual? 'literal 'other
-    ensure -> not? lessOrEqual? 'literal "literal"
-    ensure -> not? lessOrEqual? ['literal] ["literal"]
-    ensure -> not? lessOrEqual? ['literal] [literal]
-    ensure -> not? lessOrEqual? ['literal] [.literal]
-    ensure -> not? lessOrEqual? ['literal] [literal:]
+    ensure -> not? lessOrEqual? 'b 'a
+    passed
+    
+    ensure -> not? lessOrEqual? 'a "a"
+    ensure -> not? lessOrEqual? 'a "b"
+    ensure -> not? lessOrEqual? 'a `a`
+    ensure -> not? lessOrEqual? 'a `b`
+    ensure -> not? lessOrEqual? 'a to :word "a"
+    ensure -> not? lessOrEqual? 'a to :word "b"
+    ensure -> not? lessOrEqual? 'a to :label "a"
+    ensure -> not? lessOrEqual? 'a to :label "b"
+    ensure -> not? lessOrEqual? 'a to :attribute "a"
+    ensure -> not? lessOrEqual? 'a to :attribute "b"
+    ensure -> not? lessOrEqual? 'a to :attributeLabel "a"
+    ensure -> not? lessOrEqual? 'a to :attributeLabel "b"
+    ensure -> not? lessOrEqual? 'a to :type "a"
+    ensure -> not? lessOrEqual? 'a to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2552,7 +2552,6 @@ do [
     ensure -> not? greater? "b" to :attributeLabel "a"
     ensure -> not? greater? "b" to :type "a"
     passed
-    passed
     
     topic « greater? - :word
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2523,6 +2523,15 @@ do [
     passed
     
     
+    topic « greater? - :char
+    
+    ensure -> greater? `b` `a`
+    ensure -> not? greater? `a` `b`
+    ensure -> not? greater? `a` "a"
+    ensure -> not? greater? `1` 1
+    passed
+    
+    
     topic « greater? - :string
     
     ensure -> not? greater? "Art" "Arturo" -- "uro"

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -6155,39 +6155,26 @@ do [
     
     topic « lessOrEqual? - :label
     
-    ; ensure -> lessOrEqual? [a:] [b:]
-    a: [a:]
-    b: [b:]
-    ensure -> lessOrEqual? a\0 b\0
-    ensure -> lessOrEqual? [label: value] [label: value]
+    ensure -> lessOrEqual? to :label "a" to :label "a"
+    ensure -> lessOrEqual? to :label "b" to :label "b"
+    ensure -> lessOrEqual? to :label "a" to :label "b"
+    ensure -> not? lessOrEqual? to :label "b" to :label "a"
     passed
     
-    ensure -> not? lessOrEqual? [label: value] [label: value2]
-    ensure -> not? lessOrEqual? [label: value] [label2: value]
-    passed
-    
-    ensure -> not? lessOrEqual? [label: value] ["label"]
-    ensure -> not? lessOrEqual? ["label": value] ["label"]
-    ensure -> not? lessOrEqual? [label: value] ["value"]
-    ensure -> not? lessOrEqual? [label: "value"] ["value"]
-    ensure -> not? lessOrEqual? [label: "value"] ["label" "value"]
-    passed
-    
-    ensure -> not? lessOrEqual? [label: "value"] [label]
-    ensure -> not? lessOrEqual? [label: "value"] [value]
-    ensure -> not? lessOrEqual? [label: "value"] [label value]
-    passed
-    
-    ensure -> not? lessOrEqual? [label: 'world] ['label]
-    ensure -> not? lessOrEqual? [label: 'world] ['word]
-    ensure -> not? lessOrEqual? [label: 'world] ['label 'word]
-    passed
-    
-    ensure -> not? lessOrEqual? [label: .attr] [.label]
-    ensure -> not? lessOrEqual? [label: .attr] [.attr]
-    ; ensure -> not? lessOrEqual? [label: .attr: "a"] [.label: .attr: "a"]
-    ensure -> not? lessOrEqual? [label: .attr: "a"] [.label: "a"]
-    ensure -> not? lessOrEqual? [label: .attr: "a"] [.attr: "a"]
+    ensure -> not? lessOrEqual? to :label "a" "a"
+    ensure -> not? lessOrEqual? to :label "a" "b"
+    ensure -> not? lessOrEqual? to :label "a" `a`
+    ensure -> not? lessOrEqual? to :label "a" `b`
+    ensure -> not? lessOrEqual? to :label "a" 'a
+    ensure -> not? lessOrEqual? to :label "a" 'b
+    ensure -> not? lessOrEqual? to :label "a" to :word "a"
+    ensure -> not? lessOrEqual? to :label "a" to :word "b"
+    ensure -> not? lessOrEqual? to :label "a" to :attribute "a"
+    ensure -> not? lessOrEqual? to :label "a" to :attribute "b"
+    ensure -> not? lessOrEqual? to :label "a" to :attributeLabel "a"
+    ensure -> not? lessOrEqual? to :label "a" to :attributeLabel "b"
+    ensure -> not? lessOrEqual? to :label "a" to :type "a"
+    ensure -> not? lessOrEqual? to :label "a" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -888,12 +888,10 @@ do [
     
     topic « compare - :word
     
-    a: [word], b: [otherWord]
-    
-    ensure -> 0 = compare a\0 a\0
-    ensure -> 0 = compare b\0 b\0
-    ensure -> (neg 1) = compare b\0 a\0
-    ensure -> 1 = compare a\0 b\0
+    ensure -> 1 = compare to :word "b" to :word "a"
+    ensure -> 0 = compare to :word "a" to :word "a"
+    ensure -> 0 = compare to :word "b" to :word "b"
+    ensure -> (neg 1) = compare to :word "a" to :word "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -6266,7 +6266,7 @@ do [
     passed
     
     
-    topic « lessOrEqual? - :attributeLabel
+    topic « lessOrEqual? - :attributelabel
     
     ; ensure -> lessOrEqual? to :attributelabel "a" to :attributelabel "b"
     ensure -> lessOrEqual? to :attributelabel "a" to :attributelabel "a"

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -1465,29 +1465,17 @@ do [
     
     topic « equal? - :attributeLabel
     
-    ensure -> equal? [.attr: value] [.attr: value]
+    ensure -> equal? to :attributeLabel "a" to :attributeLabel "a"
+    ensure -> not? equal? to :attributeLabel "a" to :attributeLabel "b"
     passed
     
-    ensure -> not? equal? [.attr: value] ["attr"]
-    ensure -> not? equal? [.attr: value] ["value"]
-    ensure -> not? equal? [.attr: value] ["attr" "value"]
-    passed
-    
-    ; ensure -> not? equal? [.attr: value] [attr]
-    ensure -> not? equal? [.attr: value] [attr: .attr:]
-    ; ensure -> not? equal? [.attr: value] [attr: value]
-    ensure -> not? equal? [.attr: value] [attr: .attr: value]
-    passed
-    
-    ensure -> not? equal? [.attr: value] ['attr]
-    ensure -> not? equal? [.attr: value] ['value]
-    ensure -> not? equal? [.attr: value] ['attr 'value]
-    passed
-    
-    ensure -> not? equal? [.attr: value] [.attr]
-    ensure -> not? equal? [.attr: value] [.value]
-    ensure -> not? equal? [.attr: value] [.other: value]
-    ensure -> not? equal? [.attr: value] [.attr: other]
+    ensure -> not? equal? to :attributeLabel "a" "a"
+    ensure -> not? equal? to :attributeLabel "a" `a`
+    ensure -> not? equal? to :attributeLabel "a" 'a
+    ensure -> not? equal? to :attributeLabel "a" to :word "a"
+    ensure -> not? equal? to :attributeLabel "a" to :label "a"
+    ensure -> not? equal? to :attributeLabel "a" to :attribute "a"
+    ensure -> not? equal? to :attributeLabel "label" to :type "label"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -6243,11 +6243,26 @@ do [
     
     topic « lessOrEqual? - :attribute
     
-    ensure -> lessOrEqual? [.attr] [.attr]
-    ensure -> not? lessOrEqual? [.attr] ["attr"]
-    ; ensure -> not? lessOrEqual? [.attr] [attr]
-    ensure -> not? lessOrEqual? [.attr] ['attr]
-    ensure -> not? lessOrEqual? [.attr] [.other]
+    ; ensure -> lessOrEqual? to :attribute "a" to :attribute "b"
+    ensure -> lessOrEqual? to :attribute "a" to :attribute "a"
+    ensure -> lessOrEqual? to :attribute "b" to :attribute "b"
+    ensure -> not? lessOrEqual? to :attribute "b" to :attribute "a"
+    passed
+    
+    ensure -> not? lessOrEqual? to :attribute "a" "a"
+    ensure -> not? lessOrEqual? to :attribute "a" "b"
+    ensure -> not? lessOrEqual? to :attribute "a" `a`
+    ensure -> not? lessOrEqual? to :attribute "a" `b`
+    ensure -> not? lessOrEqual? to :attribute "a" 'a
+    ensure -> not? lessOrEqual? to :attribute "a" 'b
+    ensure -> not? lessOrEqual? to :attribute "a" to :word "a"
+    ensure -> not? lessOrEqual? to :attribute "a" to :word "b"
+    ensure -> not? lessOrEqual? to :attribute "a" to :label "a"
+    ensure -> not? lessOrEqual? to :attribute "a" to :label "b"
+    ensure -> not? lessOrEqual? to :attribute "a" to :attributeLabel "a"
+    ensure -> not? lessOrEqual? to :attribute "a" to :attributeLabel "b"
+    ensure -> not? lessOrEqual? to :attribute "a" to :type "a"
+    ensure -> not? lessOrEqual? to :attribute "a" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -4968,39 +4968,19 @@ do [
     
     topic « less? - :label
     
-    ; ensure -> less? [a:] [b:]
-    a: [a:]
-    b: [b:]
-    ensure -> less? a\0 b\0
-    ensure -> not? less? [label: value] [label: value]
+    ensure -> less? to :label "a" to :label "b"
+    ensure -> not? less? to :label "a" to :label "a"
+    ensure -> not? less? to :label "b" to :label "b"
+    ensure -> not? less? to :label "b" to :label "a"
     passed
     
-    ensure -> not? less? [label: value] [label: value2]
-    ensure -> not? less? [label: value] [label2: value]
-    passed
-    
-    ensure -> not? less? [label: value] ["label"]
-    ensure -> not? less? ["label": value] ["label"]
-    ensure -> not? less? [label: value] ["value"]
-    ensure -> not? less? [label: "value"] ["value"]
-    ensure -> not? less? [label: "value"] ["label" "value"]
-    passed
-    
-    ensure -> not? less? [label: "value"] [label]
-    ensure -> not? less? [label: "value"] [value]
-    ensure -> not? less? [label: "value"] [label value]
-    passed
-    
-    ensure -> not? less? [label: 'world] ['label]
-    ensure -> not? less? [label: 'world] ['word]
-    ensure -> not? less? [label: 'world] ['label 'word]
-    passed
-    
-    ensure -> not? less? [label: .attr] [.label]
-    ensure -> not? less? [label: .attr] [.attr]
-    ensure -> not? less? [label: .attr: "a"] [.label: .attr: "a"]
-    ensure -> not? less? [label: .attr: "a"] [.label: "a"]
-    ensure -> not? less? [label: .attr: "a"] [.attr: "a"]
+    ensure -> not? less? to :label "a" "b"
+    ensure -> not? less? to :label "a" `b`
+    ensure -> not? less? to :label "a" 'b
+    ensure -> not? less? to :label "a" to :word "b"
+    ensure -> not? less? to :label "a" to :attribute "b"
+    ensure -> not? less? to :label "a" to :attributeLabel "b"
+    ensure -> not? less? to :label "a" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -564,7 +564,7 @@ do [
     passed
     
     
-    topic « between? :dictionary
+    topic « between? - :dictionary
     
     a: #[name: "Walter" surname: "Pinkman"]
     
@@ -1024,7 +1024,7 @@ do [
     passed
     
     
-    topic « compare :dictionary
+    topic « compare - :dictionary
     
     a: #[name: "Walter" surname: "Pinkman"]
     
@@ -1595,7 +1595,7 @@ do [
     passed
     
     
-    topic « equal? :range
+    topic « equal? - :range
     
     ensure -> equal? [0 1 2 3 4 5] @0..5
     ensure -> equal? [0 2 4] @0.. .step: 2 5
@@ -1604,7 +1604,7 @@ do [
     passed
 
 
-    topic « equal? :dictionary
+    topic « equal? - :dictionary
     
     a: #[name: "Walter" surname: "Pinkman"]
     
@@ -2767,7 +2767,7 @@ do [
     passed
     
     
-    topic « greater? :range
+    topic « greater? - :range
     
     ensure -> not? greater? 0..5 0..5
     ensure -> not? greater? [0 1 2 3 4 5] @0..5
@@ -2777,7 +2777,7 @@ do [
     passed
     
     
-    topic « greater? :dictionary
+    topic « greater? - :dictionary
     
     a: #[name: "Walter" surname: "Pinkman"]
     
@@ -3965,7 +3965,7 @@ do [
     passed
     
     
-    topic « greaterOrEqual? :range
+    topic « greaterOrEqual? - :range
     
     ensure -> greaterOrEqual? 0..5 0..5
     ensure -> greaterOrEqual? [0 1 2 3 4 5] @0..5
@@ -3975,7 +3975,7 @@ do [
     passed
     
     
-    topic « greaterOrEqual? :dictionary
+    topic « greaterOrEqual? - :dictionary
     
     a: #[name: "Walter" surname: "Pinkman"]
     
@@ -5164,7 +5164,7 @@ do [
     passed
     
     
-    topic « less? :range
+    topic « less? - :range
     
     ensure -> not? less? [0 1 2 3 4 5] @0..5
     ensure -> not? less? [0 2 4] @0.. .step: 2 5
@@ -5173,7 +5173,7 @@ do [
     passed
     
     
-    topic « less? :dictionary
+    topic « less? - :dictionary
     
     a: #[name: "Walter" surname: "Pinkman"]
     
@@ -6362,7 +6362,7 @@ do [
     passed
     
     
-    topic « lessOrEqual? :range
+    topic « lessOrEqual? - :range
     
     ensure -> lessOrEqual? 0..5 0..5
     ensure -> lessOrEqual? [0 1 2 3 4 5] @0..5
@@ -6372,7 +6372,7 @@ do [
     passed
     
     
-    topic « lessOrEqual? :dictionary
+    topic « lessOrEqual? - :dictionary
     
     a: #[name: "Walter" surname: "Pinkman"]
     
@@ -7475,7 +7475,7 @@ do [
     passed
     
     
-    topic « notEqual? :range
+    topic « notEqual? - :range
     
     ensure -> not? notEqual? [0 1 2 3 4 5] @0..5
     ensure -> not? notEqual? [0 2 4] @0.. .step: 2 5
@@ -7484,7 +7484,7 @@ do [
     passed
     
     
-    topic « notEqual? :dictionary
+    topic « notEqual? - :dictionary
     
     a: #[name: "Walter" surname: "Pinkman"]
     
@@ -8540,7 +8540,7 @@ do [
     passed
     
     
-    topic « same? :range
+    topic « same? - :range
     
     ensure -> same? [0 1 2 3 4 5] @0..5
     ensure -> same? [0 2 4] @0.. .step: 2 5
@@ -8549,7 +8549,7 @@ do [
     passed
     
     
-    topic « same? :dictionary
+    topic « same? - :dictionary
     
     a: #[name: "Walter" surname: "Pinkman"]
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -1514,14 +1514,14 @@ do [
     
     topic « equal? - :symbol
     
-    ensure -> equal? [+] [+]
-    ensure -> not? equal? [+] [-]
-    ensure -> not? equal? [+] [++]
-    ensure -> not? equal? [+] [`+`]
-    ensure -> not? equal? [+] [{+}]
-    ensure -> not? equal? [+] ["+"]
-    ensure -> not? equal? [+] [plus]
-    ensure -> not? equal? [+] ['+]
+    ensure -> equal? to :symbol "+" to :symbol "+"
+    ensure -> not? equal? to :symbol "+" to :symbol "-"
+    ensure -> not? equal? to :symbol "+" "++"
+    ensure -> not? equal? to :symbol "+" `+`
+    ensure -> not? equal? to :symbol "+" {+}
+    ensure -> not? equal? to :symbol "+" "+"
+    ensure -> not? equal? to :symbol "+" to :word "plus"
+    ensure -> not? equal? to :symbol "+" '+
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -7314,26 +7314,20 @@ do [
     ensure -> notEqual? to :attribute "text" to :type "label"
     passed
     
-    ensure -> notEqual? [.attr: value] ["attr"]
-    ensure -> notEqual? [.attr: value] ["value"]
-    ensure -> notEqual? [.attr: value] ["attr" "value"]
+
+    topic « notEqual? - :attributelabel
+    
+    ensure -> notEqual? to :attributelabel "a" to :attributelabel "b"
+    ensure -> not? notEqual? to :attributelabel "a" to :attributelabel "a"
     passed
     
-    ; ensure -> notEqual? [.attr: value] [attr]
-    ensure -> notEqual? [.attr: value] [attr: .attr:]
-    ; ensure -> notEqual? [.attr: value] [attr: value]
-    ensure -> notEqual? [.attr: value] [attr: .attr: value]
-    passed
-    
-    ensure -> notEqual? [.attr: value] ['attr]
-    ensure -> notEqual? [.attr: value] ['value]
-    ensure -> notEqual? [.attr: value] ['attr 'value]
-    passed
-    
-    ensure -> notEqual? [.attr: value] [.attr]
-    ensure -> notEqual? [.attr: value] [.value]
-    ensure -> notEqual? [.attr: value] [.other: value]
-    ensure -> notEqual? [.attr: value] [.attr: other]
+    ensure -> notEqual? to :attributelabel "b" "a"
+    ensure -> notEqual? to :attributelabel "b" `a`
+    ensure -> notEqual? to :attributelabel "b" 'a
+    ensure -> notEqual? to :attributelabel "b" to :word "a"
+    ensure -> notEqual? to :attributelabel "b" to :label "a"
+    ensure -> notEqual? to :attributelabel "b" to :attribute "a"
+    ensure -> notEqual? to :attributelabel "text" to :type "label"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -3716,20 +3716,20 @@ do [
     ensure -> greaterOrEqual? "Artu" "Art"
     passed
     
-    ensure -> not? greater? "b" `a`
-    ensure -> not? greater? "b" `b`
-    ensure -> not? greater? "b" 'a
-    ensure -> not? greater? "b" 'b
-    ensure -> not? greater? "b" to :word "a"
-    ensure -> not? greater? "b" to :word "b"
-    ensure -> not? greater? "b" to :label "a"
-    ensure -> not? greater? "b" to :label "b"
-    ensure -> not? greater? "b" to :attribute "a"
-    ensure -> not? greater? "b" to :attribute "b"
-    ensure -> not? greater? "b" to :attributeLabel "a"
-    ensure -> not? greater? "b" to :attributeLabel "b"
-    ensure -> not? greater? "b" to :type "a"
-    ensure -> not? greater? "b" to :type "b"
+    ensure -> not? greaterOrEqual? "b" `a`
+    ensure -> not? greaterOrEqual? "b" `b`
+    ensure -> not? greaterOrEqual? "b" 'a
+    ensure -> not? greaterOrEqual? "b" 'b
+    ensure -> not? greaterOrEqual? "b" to :word "a"
+    ensure -> not? greaterOrEqual? "b" to :word "b"
+    ensure -> not? greaterOrEqual? "b" to :label "a"
+    ensure -> not? greaterOrEqual? "b" to :label "b"
+    ensure -> not? greaterOrEqual? "b" to :attribute "a"
+    ensure -> not? greaterOrEqual? "b" to :attribute "b"
+    ensure -> not? greaterOrEqual? "b" to :attributeLabel "a"
+    ensure -> not? greaterOrEqual? "b" to :attributeLabel "b"
+    ensure -> not? greaterOrEqual? "b" to :type "a"
+    ensure -> not? greaterOrEqual? "b" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -3761,36 +3761,26 @@ do [
     
     topic « greaterOrEqual? - :label
     
-    ensure -> not? greaterOrEqual? [a:] [b:]
-    ensure -> not? greaterOrEqual? [b:] [a:]
-    a: [a:]
-    b: [b:]
-    ; ensure -> greaterOrEqual? a\0 b\0
-    ensure -> greaterOrEqual? [label: value] [label: value]
+    ensure -> greaterOrEqual? to :label "b" to :label "a"
+    ensure -> greaterOrEqual? to :label "a" to :label "a"
+    ensure -> greaterOrEqual? to :label "b" to :label "b"
+    ensure -> not? greaterOrEqual? to :label "a" to :label "b"
     passed
     
-    ensure -> not? greaterOrEqual? [label: value] [label: value2]
-    ensure -> not? greaterOrEqual? [label: value] [label2: value]
-    passed
-    
-    ensure -> not? greaterOrEqual? [label:] ["label"]
-    ensure -> not? greaterOrEqual? ["label":] ["label"]
-    ensure -> not? greaterOrEqual? [label:] ["value"]
-    ensure -> not? greaterOrEqual? [label:] ["value"]
-    ensure -> not? greaterOrEqual? [label: "value"] ["label" "value"]
-    passed
-    
-    ; ensure -> not? greaterOrEqual? [label:] [label]
-    ensure -> not? greaterOrEqual? [label:] [value]
-    ensure -> not? greaterOrEqual? [label: "value"] [label value]
-    passed
-    
-    ensure -> not? greaterOrEqual? [label:] ['label]
-    ensure -> not? greaterOrEqual? [label: 'world] ['label 'word]
-    passed
-    
-    ; ensure -> not? greaterOrEqual? [label: .attr] [.label .attr]
-    ; ensure -> not? greaterOrEqual? [label: .attr: "a"] [.label: .attr: "a"]
+    ensure -> not? greaterOrEqual? to :label "b" "a"
+    ensure -> not? greaterOrEqual? to :label "b" "b"
+    ensure -> not? greaterOrEqual? to :label "b" `a`
+    ensure -> not? greaterOrEqual? to :label "b" `b`
+    ensure -> not? greaterOrEqual? to :label "b" 'a
+    ensure -> not? greaterOrEqual? to :label "b" 'b
+    ensure -> not? greaterOrEqual? to :label "b" to :word "a"
+    ensure -> not? greaterOrEqual? to :label "b" to :word "b"
+    ensure -> not? greaterOrEqual? to :label "b" to :attribute "a"
+    ensure -> not? greaterOrEqual? to :label "b" to :attribute "b"
+    ensure -> not? greaterOrEqual? to :label "b" to :attributeLabel "a"
+    ensure -> not? greaterOrEqual? to :label "b" to :attributeLabel "b"
+    ensure -> not? greaterOrEqual? to :label "b" to :type "a"
+    ensure -> not? greaterOrEqual? to :label "b" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -7246,22 +7246,12 @@ do [
     ensure -> notEqual? "Art" "Bob"
     passed
     
-    ensure -> notEqual? "a"    `a` 
-    ensure -> notEqual? "10"   10 
-    ensure -> notEqual? "10"   10
-    ensure -> notEqual? ["help"] [help]
-    ensure -> notEqual? ["a"]    [a: "a"]
-    ensure -> notEqual? "help"   'help
-    ensure -> notEqual? ["help"] [.help]
-    ensure -> notEqual? ["help"] ['help: "help"]
-    ensure -> "a"      <> `a` 
-    ensure -> "10"     <> 10 
-    ensure -> "10"     <> 10
-    ensure -> ["help"] <> [help]
-    ensure -> ["a"]    <> [a: "a"]
-    ensure -> "help"   <> 'help
-    ensure -> ["help"] <> [.help]
-    ensure -> ["help"] <> ['help: "help"]
+    ensure -> notEqual? "b" `a`
+    ensure -> notEqual? "b" 'a
+    ensure -> notEqual? "b" to :label "a"
+    ensure -> notEqual? "b" to :attribute "a"
+    ensure -> notEqual? "b" to :attributeLabel "a"
+    ensure -> notEqual? "text" to :type "string"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -3716,20 +3716,20 @@ do [
     ensure -> greaterOrEqual? "Artu" "Art"
     passed
     
-    ensure -> not? greaterOrEqual? "a"    `a` 
-    ensure -> not? greaterOrEqual? "10"   10 
-    ensure -> not? greaterOrEqual? "10"   10
-    ensure -> not? greaterOrEqual? ["help"] [help]
-    ensure -> not? greaterOrEqual? ["a"]    [a:]
-    ensure -> not? greaterOrEqual? "help"   'help
-    ensure -> not? greaterOrEqual? ["help"] [.help]
-    ensure -> not? "a"      >= `a` 
-    ensure -> not? "10"     >= 10 
-    ensure -> not? "10"     >= 10
-    ensure -> not? ["help"] >= [help]
-    ensure -> not? ["a"]    >= [a:]
-    ensure -> not? "help"   >= 'help
-    ensure -> not? ["help"] >= [.help]
+    ensure -> not? greater? "b" `a`
+    ensure -> not? greater? "b" `b`
+    ensure -> not? greater? "b" 'a
+    ensure -> not? greater? "b" 'b
+    ensure -> not? greater? "b" to :word "a"
+    ensure -> not? greater? "b" to :word "b"
+    ensure -> not? greater? "b" to :label "a"
+    ensure -> not? greater? "b" to :label "b"
+    ensure -> not? greater? "b" to :attribute "a"
+    ensure -> not? greater? "b" to :attribute "b"
+    ensure -> not? greater? "b" to :attributeLabel "a"
+    ensure -> not? greater? "b" to :attributeLabel "b"
+    ensure -> not? greater? "b" to :type "a"
+    ensure -> not? greater? "b" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -5075,14 +5075,14 @@ do [
     
     topic « less? - :symbol
     
-    ensure -> not? less? [+] [+]
-    ensure -> not? less? [+] [-]
-    ensure -> not? less? [+] [++]
-    ensure -> not? less? [+] [`+`]
-    ensure -> not? less? [+] [{+}]
-    ensure -> not? less? [+] ["+"]
-    ensure -> not? less? [+] [plus]
-    ensure -> not? less? [+] ['+]
+    ensure -> not? less? to :symbol "+" to :symbol "+"
+    ensure -> not? less? to :symbol "+" to :symbol "-"
+    ensure -> not? less? to :symbol "+" to :symbol "++"
+    ensure -> not? less? to :symbol "+" `+`
+    ensure -> not? less? to :symbol "+" {+}
+    ensure -> not? less? to :symbol "+" "+"
+    ensure -> not? less? to :symbol "+" to :word "plus"
+    ensure -> not? less? to :symbol "+" '+
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2675,14 +2675,14 @@ do [
     
     topic « greater? - :symbol
     
-    ensure -> not? greater? [+] [+]
-    ensure -> not? greater? [+] [-]
-    ensure -> not? greater? [+] [++]
-    ensure -> not? greater? [+] [`+`]
-    ensure -> not? greater? [+] [{+}]
-    ensure -> not? greater? [+] ["+"]
-    ensure -> not? greater? [+] [plus]
-    ensure -> not? greater? [+] ['+]
+    ensure -> not? greater? to :symbol "+" to :symbol "+"
+    ensure -> not? greater? to :symbol "+" to :symbol "-"
+    ensure -> not? greater? to :symbol "+" to :symbol "++"
+    ensure -> not? greater? to :symbol "+" `+`
+    ensure -> not? greater? to :symbol "+" {+}
+    ensure -> not? greater? to :symbol "+" "+"
+    ensure -> not? greater? to :symbol "+" to :word "plus"
+    ensure -> not? greater? to :symbol "+" '+
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -8291,13 +8291,17 @@ do [
     
     topic « same? - :word
     
-    ensure -> same? [word] [word]
-    ensure -> not? same? [word] [otherWord]
-    ensure -> not? same? [word] ["word"]
-    ensure -> not? same? [word] [word: word]
-    ensure -> not? same? [word] ['word]
-    ; ensure -> not? same? [word] [.word]
-    ensure -> not? same? [word] [.word: word]
+    ensure -> same? to :word "a" to :word "a"
+    ensure -> not? same? to :word "a" to :word "b"
+    passed
+    
+    ensure -> not? same? to :word "a" "a"
+    ensure -> not? same? to :word "a" `a`
+    ensure -> not? same? to :word "a" 'a
+    ensure -> not? same? to :word "a" to :label "a"
+    ensure -> not? same? to :word "a" to :attribute "a"
+    ensure -> not? same? to :word "a" to :attributelabel "a"
+    ensure -> not? same? to :word "word" to :type "word"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -4939,20 +4939,13 @@ do [
     ensure -> less? "Art" "Artu"
     passed
     
-    ensure -> not? less? "a"    `a` 
-    ensure -> not? less? "10"   10 
-    ensure -> not? less? "10"   10
-    ensure -> not? less? ["help"] [help]
-    ensure -> not? less? ["a"]    [a:]
-    ensure -> not? less? "help"   'help
-    ensure -> not? less? ["help"] [.help]
-    ensure -> not? "a"      < `a` 
-    ensure -> not? "10"     < 10 
-    ensure -> not? "10"     < 10
-    ensure -> not? ["help"] < [help]
-    ensure -> not? ["a"]    < [a:]
-    ensure -> not? "help"   < 'help
-    ensure -> not? ["help"] < [.help]
+    ensure -> not? less? "a" `b`
+    ensure -> not? less? "a" 'b
+    ensure -> not? less? "a" to :word "b"
+    ensure -> not? less? "a" to :label "b"
+    ensure -> not? less? "a" to :attribute "b"
+    ensure -> not? less? "a" to :attributeLabel "b"
+    ensure -> not? less? "a" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -7267,13 +7267,17 @@ do [
     
     topic « notEqual? - :word
     
-    ensure -> not? notEqual? [word] [word]
-    ensure -> notEqual? [word] [otherWord]
-    ensure -> notEqual? [word] ["word"]
-    ensure -> notEqual? [word] [word: word]
-    ensure -> notEqual? [word] ['word]
-    ; ensure -> notEqual? [word] [.word]
-    ensure -> notEqual? [word] [.word: word]
+    ensure -> notEqual? to :word "a" to :word "b"
+    ensure -> not? notEqual? to :word "a" to :word "a"
+    passed
+    
+    ensure -> notEqual? to :word "a" "a"
+    ensure -> notEqual? to :word "a" `a`
+    ensure -> notEqual? to :word "a" 'a
+    ensure -> notEqual? to :word "a" to :label "a"
+    ensure -> notEqual? to :word "a" to :attribute "a"
+    ensure -> notEqual? to :word "a" to :attributeLabel "a"
+    ensure -> notEqual? to :word "word" to :type "word"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2544,13 +2544,13 @@ do [
     ensure -> greater? "Artu" "Art"
     passed
     
-    ensure -> not? greater? "a" `a`
-    ensure -> not? greater? "a" 'a
-    ensure -> not? greater? "a" to :word "a"
-    ensure -> not? greater? "a" to :label "a"
-    ensure -> not? greater? "a" to :attribute "a"
-    ensure -> not? greater? "a" to :attributeLabel "a"
-    ensure -> not? greater? "string" to :type "string"
+    ensure -> not? greater? "b" `a`
+    ensure -> not? greater? "b" 'a
+    ensure -> not? greater? "b" to :word "a"
+    ensure -> not? greater? "b" to :label "a"
+    ensure -> not? greater? "b" to :attribute "a"
+    ensure -> not? greater? "b" to :attributeLabel "a"
+    ensure -> not? greater? "b" to :type "a"
     passed
     passed
     
@@ -2561,13 +2561,13 @@ do [
     ensure -> not? greater? to :word "a" to :word "b"
     passed
     
-    ensure -> not? greater? to :word "a" "a"
-    ensure -> not? greater? to :word "a" `a`
-    ensure -> not? greater? to :word "a" 'a
-    ensure -> not? greater? to :word "a" to :label "a"
-    ensure -> not? greater? to :word "a" to :attribute "a"
-    ensure -> not? greater? to :word "a" to :attributeLabel "a"
-    ensure -> not? greater? to :word "word" to :type "word"
+    ensure -> not? greater? to :word "b" "a"
+    ensure -> not? greater? to :word "b" `a`
+    ensure -> not? greater? to :word "b" 'a
+    ensure -> not? greater? to :word "b" to :label "a"
+    ensure -> not? greater? to :word "b" to :attribute "a"
+    ensure -> not? greater? to :word "b" to :attributeLabel "a"
+    ensure -> not? greater? to :word "b" to :type "a"
     passed
     
     
@@ -2578,13 +2578,13 @@ do [
     ensure -> not? greater? to :label "a" to :label "b"
     passed
     
-    ensure -> not? greater? to :label "a" "a"
-    ensure -> not? greater? to :label "a" `a`
-    ensure -> not? greater? to :label "a" 'a
-    ensure -> not? greater? to :label "a" to :word "a"
-    ensure -> not? greater? to :label "a" to :attribute "a"
-    ensure -> not? greater? to :label "a" to :attributeLabel "a"
-    ensure -> not? greater? to :label "label" to :type "label"
+    ensure -> not? greater? to :label "b" "a"
+    ensure -> not? greater? to :label "b" `a`
+    ensure -> not? greater? to :label "b" 'a
+    ensure -> not? greater? to :label "b" to :word "a"
+    ensure -> not? greater? to :label "b" to :attribute "a"
+    ensure -> not? greater? to :label "b" to :attributeLabel "a"
+    ensure -> not? greater? to :label "b" to :type "a"
     passed
     
     
@@ -2595,13 +2595,13 @@ do [
     ensure -> not? greater? 'a 'b
     passed
     
-    ensure -> not? greater? 'a "a"
-    ensure -> not? greater? 'a `a`
-    ensure -> not? greater? 'a to :word "a"
-    ensure -> not? greater? 'a to :label "a"
-    ensure -> not? greater? 'a to :attribute "a"
-    ensure -> not? greater? 'a to :attributeLabel "a"
-    ensure -> not? greater? 'literal to :type "literal"
+    ensure -> not? greater? 'b "a"
+    ensure -> not? greater? 'b `a`
+    ensure -> not? greater? 'b to :word "a"
+    ensure -> not? greater? 'b to :label "a"
+    ensure -> not? greater? 'b to :attribute "a"
+    ensure -> not? greater? 'b to :attributeLabel "a"
+    ensure -> not? greater? 'b to :type "a"
     passed
     
     
@@ -2650,13 +2650,13 @@ do [
     ensure -> not? greater? to :attribute "a" to :attribute "b"
     passed
     
-    ensure -> not? greater? to :attribute "a" "a"
-    ensure -> not? greater? to :attribute "a" `a`
-    ensure -> not? greater? to :attribute "a" 'a
-    ensure -> not? greater? to :attribute "a" to :word "a"
-    ensure -> not? greater? to :attribute "a" to :label "a"
-    ensure -> not? greater? to :attribute "a" to :attributeLabel "a"
-    ensure -> not? greater? to :attribute "attribute" to :type "attribute"
+    ensure -> not? greater? to :attribute "b" "a"
+    ensure -> not? greater? to :attribute "b" `a`
+    ensure -> not? greater? to :attribute "b" 'a
+    ensure -> not? greater? to :attribute "b" to :word "a"
+    ensure -> not? greater? to :attribute "b" to :label "a"
+    ensure -> not? greater? to :attribute "b" to :attributeLabel "a"
+    ensure -> not? greater? to :attribute "b" to :type "a"
     passed
 
     
@@ -2667,14 +2667,14 @@ do [
     ensure -> not? greater? to :attributeLabel "a" to :attributeLabel "b"
     passed
     
-    ensure -> not? greater? to :attributeLabel "a" "a"
-    ensure -> not? greater? to :attributeLabel "a" `a`
-    ensure -> not? greater? to :attributeLabel "a" 'a
-    ensure -> not? greater? to :attributeLabel "a" to :word "a"
-    ensure -> not? greater? to :attributeLabel "a" to :label "a"
-    ensure -> not? greater? to :attributeLabel "a" to :attribute "a"
-    ensure -> not? greater? to :attributeLabel "attributeLabel" 
-                            to :type "attributeLabel"
+    ensure -> not? greater? to :attributeLabel "less" "a"
+    ensure -> not? greater? to :attributeLabel "less" `a`
+    ensure -> not? greater? to :attributeLabel "less" 'a
+    ensure -> not? greater? to :attributeLabel "less" to :word "a"
+    ensure -> not? greater? to :attributeLabel "less" to :label "a"
+    ensure -> not? greater? to :attributeLabel "less" to :attribute "a"
+    ensure -> not? greater? to :attributeLabel "b" 
+                            to :type "a"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -3861,32 +3861,28 @@ do [
     passed
     
     
-    topic « greaterOrEqual? - :attributeLabel
+    topic « greaterOrEqual? - :attributelabel
     
-    ensure -> greaterOrEqual? [.attr: value] [.attr: value]
-    ; ensure -> greaterOrEqual? [.b:] [.a:]
+    ; ensure -> greaterOrEqual? to :attributelabel "b" to :attributelabel "a"
+    ensure -> greaterOrEqual? to :attributelabel "a" to :attributelabel "a"
+    ensure -> greaterOrEqual? to :attributelabel "b" to :attributelabel "b"
+    ensure -> not? greaterOrEqual? to :attributelabel "a" to :attributelabel "b"
     passed
     
-    ensure -> not? greaterOrEqual? [.attr:] ["attr"]
-    ensure -> not? greaterOrEqual? [.attr:] ["value"]
-    ensure -> not? greaterOrEqual? [.attr: value] ["attr" "value"]
-    passed
-    
-    ; ensure -> not? greaterOrEqual? [.attr:] [attr]
-    ensure -> not? greaterOrEqual? [.attr: value] [attr: .attr:]
-    ; ensure -> not? greaterOrEqual? [.attr: value] [attr: value]
-    ensure -> not? greaterOrEqual? [.attr: value] [attr: .attr:]
-    passed
-    
-    ensure -> not? greaterOrEqual? [.attr:] ['attr]
-    ensure -> not? greaterOrEqual? [.attr:] ['value]
-    ensure -> not? greaterOrEqual? [.attr: value] ['attr 'value]
-    passed
-    
-    ; ensure -> not? greaterOrEqual? [.attr:] [.attr]
-    ensure -> not? greaterOrEqual? [.attr:] [.value]
-    ensure -> not? greaterOrEqual? [.attr: value] [.other: value]
-    ensure -> not? greaterOrEqual? [.attr: value] [.attr: other]
+    ensure -> not? greaterOrEqual? to :attributelabel "b" "a"
+    ensure -> not? greaterOrEqual? to :attributelabel "b" "b"
+    ensure -> not? greaterOrEqual? to :attributelabel "b" `a`
+    ensure -> not? greaterOrEqual? to :attributelabel "b" `b`
+    ensure -> not? greaterOrEqual? to :attributelabel "b" 'a
+    ensure -> not? greaterOrEqual? to :attributelabel "b" 'b
+    ensure -> not? greaterOrEqual? to :attributelabel "b" to :word "a"
+    ensure -> not? greaterOrEqual? to :attributelabel "b" to :word "b"
+    ensure -> not? greaterOrEqual? to :attributelabel "b" to :label "a"
+    ensure -> not? greaterOrEqual? to :attributelabel "b" to :label "b"
+    ensure -> not? greaterOrEqual? to :attributelabel "b" to :attribute "a"
+    ensure -> not? greaterOrEqual? to :attributelabel "b" to :attribute "b"
+    ensure -> not? greaterOrEqual? to :attributelabel "b" to :type "a"
+    ensure -> not? greaterOrEqual? to :attributelabel "b" to :type "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2641,14 +2641,20 @@ do [
     
     topic « greater? - :attribute
     
-    ensure -> not? greater? [.attr] [.attr]
-    ensure -> not? greater? [.a] [.b]
-    ensure -> not? greater? [.attr] ["attr"]
-    ; ensure -> not? greater? [.attr] [attr]
-    ensure -> not? greater? [.attr] ['attr]
-    ensure -> not? greater? [.attr] [.other]
+    ; ensure -> greater? to :attribute "b" to :attribute "a"
+    ensure -> not? greater? to :attribute "a" to :attribute "a"
+    ensure -> not? greater? to :attribute "a" to :attribute "b"
     passed
     
+    ensure -> not? greater? to :attribute "a" "a"
+    ensure -> not? greater? to :attribute "a" `a`
+    ensure -> not? greater? to :attribute "a" 'a
+    ensure -> not? greater? to :attribute "a" to :word "a"
+    ensure -> not? greater? to :attribute "a" to :label "a"
+    ensure -> not? greater? to :attribute "a" to :attributeLabel "a"
+    ensure -> not? greater? to :attribute "word" to :type "word"
+    passed
+
     
     topic « greaterOrEqual? - :attributeLabel
     

--- a/tests/unittests/lib.comparison.res
+++ b/tests/unittests/lib.comparison.res
@@ -86,7 +86,7 @@
 >> between? - :block
 [+] passed!
 
->> between? :dictionary
+>> between? - :dictionary
 [+] passed!
 
 >> between? - :object
@@ -182,7 +182,7 @@
 >> compare - :range
 [+] passed!
 
->> compare :dictionary
+>> compare - :dictionary
 [+] passed!
 
 >> compare - :object
@@ -298,10 +298,10 @@
 >> equal? - :block
 [+] passed!
 
->> equal? :range
+>> equal? - :range
 [+] passed!
 
->> equal? :dictionary
+>> equal? - :dictionary
 [+] passed!
 [+] passed!
 
@@ -461,10 +461,10 @@
 >> greater? - :block
 [+] passed!
 
->> greater? :range
+>> greater? - :range
 [+] passed!
 
->> greater? :dictionary
+>> greater? - :dictionary
 [+] passed!
 
 >> greater? - :object
@@ -627,10 +627,10 @@
 >> greaterOrEqual? - :block
 [+] passed!
 
->> greaterOrEqual? :range
+>> greaterOrEqual? - :range
 [+] passed!
 
->> greaterOrEqual? :dictionary
+>> greaterOrEqual? - :dictionary
 [+] passed!
 
 >> greaterOrEqual? - :object
@@ -792,10 +792,10 @@
 >> less? - :block
 [+] passed!
 
->> less? :range
+>> less? - :range
 [+] passed!
 
->> less? :dictionary
+>> less? - :dictionary
 [+] passed!
 
 >> less? - :object
@@ -958,10 +958,10 @@
 >> lessOrEqual? - :block
 [+] passed!
 
->> lessOrEqual? :range
+>> lessOrEqual? - :range
 [+] passed!
 
->> lessOrEqual? :dictionary
+>> lessOrEqual? - :dictionary
 [+] passed!
 
 >> lessOrEqual? - :object
@@ -1115,10 +1115,10 @@
 >> notEqual? - :block
 [+] passed!
 
->> notEqual? :range
+>> notEqual? - :range
 [+] passed!
 
->> notEqual? :dictionary
+>> notEqual? - :dictionary
 [+] passed!
 [+] passed!
 
@@ -1278,10 +1278,10 @@
 >> same? - :block
 [+] passed!
 
->> same? :range
+>> same? - :range
 [+] passed!
 
->> same? :dictionary
+>> same? - :dictionary
 [+] passed!
 [+] passed!
 

--- a/tests/unittests/lib.comparison.res
+++ b/tests/unittests/lib.comparison.res
@@ -403,23 +403,25 @@
 [+] passed!
 [+] passed!
 
+>> greater? - :char
+[+] passed!
+
 >> greater? - :string
+[+] passed!
 [+] passed!
 [+] passed!
 [+] passed!
 
 >> greater? - :word
 [+] passed!
+[+] passed!
 
->> Equal? - :label
-[+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
+>> greater? - :label
 [+] passed!
 [+] passed!
 
 >> greater? - :literal
+[+] passed!
 [+] passed!
 
 >> greater? - :path
@@ -433,11 +435,9 @@
 
 >> greater? - :attribute
 [+] passed!
+[+] passed!
 
->> greaterOrEqual? - :attributeLabel
-[+] passed!
-[+] passed!
-[+] passed!
+>> greater? - :attributeLabel
 [+] passed!
 [+] passed!
 
@@ -471,7 +471,7 @@
 [+] passed!
 [+] passed!
 
->> greaterOrEqual? - :store
+>> greater? - :store
 [+] passed!
 [+] passed!
 

--- a/tests/unittests/lib.comparison.res
+++ b/tests/unittests/lib.comparison.res
@@ -77,7 +77,7 @@
 >> between? - :attribute
 [+] passed!
 
->> between? - :attributeLabel
+>> between? - :attributelabel
 [+] passed!
 
 >> between? - :inline
@@ -264,7 +264,7 @@
 [+] passed!
 [+] passed!
 
->> equal? - :attributeLabel
+>> equal? - :attributelabel
 [+] passed!
 [+] passed!
 
@@ -436,7 +436,7 @@
 [+] passed!
 [+] passed!
 
->> greater? - :attributeLabel
+>> greater? - :attributelabel
 [+] passed!
 [+] passed!
 
@@ -1208,25 +1208,21 @@
 
 >> same? - :word
 [+] passed!
+[+] passed!
 
 >> same? - :label
-[+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
 [+] passed!
 [+] passed!
 
 >> same? - :literal
 [+] passed!
+[+] passed!
 
 >> same? - :attribute
 [+] passed!
+[+] passed!
 
->> same? - :attributeLabel
-[+] passed!
-[+] passed!
-[+] passed!
+>> same? - :attributelabel
 [+] passed!
 [+] passed!
 

--- a/tests/unittests/lib.comparison.res
+++ b/tests/unittests/lib.comparison.res
@@ -246,28 +246,25 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
 
 >> equal? - :word
+[+] passed!
 [+] passed!
 
 >> equal? - :label
 [+] passed!
 [+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
 
 >> equal? - :literal
+[+] passed!
 [+] passed!
 
 >> equal? - :attribute
 [+] passed!
+[+] passed!
 
 >> equal? - :attributeLabel
-[+] passed!
-[+] passed!
-[+] passed!
 [+] passed!
 [+] passed!
 

--- a/tests/unittests/lib.comparison.res
+++ b/tests/unittests/lib.comparison.res
@@ -1050,12 +1050,9 @@
 
 >> notEqual? - :word
 [+] passed!
+[+] passed!
 
 >> notEqual? - :label
-[+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
 [+] passed!
 [+] passed!
 
@@ -1064,11 +1061,9 @@
 
 >> notEqual? - :attribute
 [+] passed!
+[+] passed!
 
->> notEqual? - :attributeLabel
-[+] passed!
-[+] passed!
-[+] passed!
+>> notEqual? - :attributelabel
 [+] passed!
 [+] passed!
 

--- a/tests/unittests/lib.comparison.res
+++ b/tests/unittests/lib.comparison.res
@@ -410,7 +410,6 @@
 [+] passed!
 [+] passed!
 [+] passed!
-[+] passed!
 
 >> greater? - :word
 [+] passed!
@@ -576,16 +575,14 @@
 
 >> greaterOrEqual? - :word
 [+] passed!
+[+] passed!
 
 >> greaterOrEqual? - :label
 [+] passed!
 [+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
 
 >> greaterOrEqual? - :literal
+[+] passed!
 [+] passed!
 
 >> greaterOrEqual? - :path
@@ -599,11 +596,9 @@
 
 >> greaterOrEqual? - :attribute
 [+] passed!
+[+] passed!
 
->> greaterOrEqual? - :attributeLabel
-[+] passed!
-[+] passed!
-[+] passed!
+>> greaterOrEqual? - :attributelabel
 [+] passed!
 [+] passed!
 
@@ -742,16 +737,14 @@
 
 >> less? - :word
 [+] passed!
+[+] passed!
 
 >> less? - :label
 [+] passed!
 [+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
 
 >> less? - :literal
+[+] passed!
 [+] passed!
 
 >> less? - :path
@@ -765,11 +758,9 @@
 
 >> less? - :attribute
 [+] passed!
+[+] passed!
 
->> less? - :attributeLabel
-[+] passed!
-[+] passed!
-[+] passed!
+>> less? - :attributelabel
 [+] passed!
 [+] passed!
 
@@ -908,16 +899,14 @@
 
 >> lessOrEqual? - :word
 [+] passed!
+[+] passed!
 
 >> lessOrEqual? - :label
 [+] passed!
 [+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
 
 >> lessOrEqual? - :literal
+[+] passed!
 [+] passed!
 
 >> lessOrEqual? - :path
@@ -931,11 +920,9 @@
 
 >> lessOrEqual? - :attribute
 [+] passed!
+[+] passed!
 
->> lessOrEqual? - :attributeLabel
-[+] passed!
-[+] passed!
-[+] passed!
+>> lessOrEqual? - :attributelabel
 [+] passed!
 [+] passed!
 

--- a/tests/unittests/lib.comparison.res
+++ b/tests/unittests/lib.comparison.res
@@ -152,7 +152,7 @@
 >> compare - :attribute
 [+] passed!
 
->> compare - :attributeLabel
+>> compare - :attributelabel
 [+] passed!
 
 >> compare - :path


### PR DESCRIPTION
# Description

Unit-test for [Comparison Lib](https://arturo-lang.io/documentation/library/comparison/).

This'll be a veeeery long list...

- [x] `between?`
- [x] `comapare`
  - [ ] `:database`
- [x] `equal?`
  - [ ] `:database`
- [x] `greater?`
  - [ ] `:database`
- [x] `greaterOrEqual?`
  - [ ] `:database`
- [x] `less?`
  - [ ] `:database`
- [x] `lessOrEqual?`
  - [ ] `:database`
- [x] `notEqual?`
  - [ ] `:database`
- [x] `same?`
  - [ ] `:database`

## Type of change

- [x] Add/Update unit-tests