### PR TITLE
[Comparison] add support to `:attribute` and `:attibutelabel`

### DIFF
--- a/src/vm/values/comparison.nim
+++ b/src/vm/values/comparison.nim
@@ -363,7 +363,9 @@ proc `<`*(x: Value, y: Value): bool {.inline.}=
             of String,
                Word,
                Label,
-               Literal: return x.s < y.s
+               Literal,
+               Attribute,
+               AttributeLabel: return x.s < y.s
             of Symbol: return false
             of Inline,
                Block:

--- a/src/vm/values/comparison.nim
+++ b/src/vm/values/comparison.nim
@@ -453,7 +453,9 @@ proc `>`*(x: Value, y: Value): bool {.inline.}=
             of String,
                Word,
                Label,
-               Literal: return x.s > y.s
+               Literal,
+               Attribute,
+               AttributeLabel: return x.s > y.s
             of Symbol: return false
             of Inline,
                Block:

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -917,7 +917,7 @@ do [
     ensure -> 1 = compare to :attribute "b" to :attribute "a"
     ensure -> 0 = compare to :attribute "a" to :attribute "a"
     ensure -> 0 = compare to :attribute "b" to :attribute "b"
-    ; ensure -> (neg 1) = compare to :attribute "a" to :attribute "b"
+    ensure -> (neg 1) = compare to :attribute "a" to :attribute "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2653,7 +2653,7 @@ do [
     
     topic « greater? - :attributelabel
     
-    ; ensure -> greater? to :attributelabel "b" to :attributelabel "a"
+    ensure -> greater? to :attributelabel "b" to :attributelabel "a"
     ensure -> not? greater? to :attributelabel "a" to :attributelabel "a"
     ensure -> not? greater? to :attributelabel "a" to :attributelabel "b"
     passed

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -542,8 +542,8 @@ do [
     topic « between? - :attributelabel
     
     ensure -> between? to :attributelabel "C" to :attributelabel "Arturo" to :attributelabel "Ruby"
-    ; ensure -> not? between? to :attributelabel "C" to :attributelabel "Arturo" to :attributelabel "Barry"
-    ; ensure -> not? between? to :attributelabel "C" to :attributelabel "Python" to :attributelabel "Ruby"
+    ensure -> not? between? to :attributelabel "C" to :attributelabel "Arturo" to :attributelabel "Barry"
+    ensure -> not? between? to :attributelabel "C" to :attributelabel "Python" to :attributelabel "Ruby"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -5049,7 +5049,7 @@ do [
     
     topic « less? - :attributelabel
     
-    ; ensure -> less? to :attributelabel "a" to :attributelabel "b"
+    ensure -> less? to :attributelabel "a" to :attributelabel "b"
     ensure -> not? less? to :attributelabel "a" to :attributelabel "a"
     ensure -> not? less? to :attributelabel "b" to :attributelabel "b"
     ensure -> not? less? to :attributelabel "b" to :attributelabel "a"

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -926,7 +926,7 @@ do [
     ensure -> 1 = compare to :attributelabel "b" to :attributelabel "a"
     ensure -> 0 = compare to :attributelabel "a" to :attributelabel "a"
     ensure -> 0 = compare to :attributelabel "b" to :attributelabel "b"
-    ; ensure -> (neg 1) = compare to :attributelabel "a" to :attributelabel "b"
+    ensure -> (neg 1) = compare to :attributelabel "a" to :attributelabel "b"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2636,7 +2636,7 @@ do [
     
     topic « greater? - :attribute
     
-    ; ensure -> greater? to :attribute "b" to :attribute "a"
+    ensure -> greater? to :attribute "b" to :attribute "a"
     ensure -> not? greater? to :attribute "a" to :attribute "a"
     ensure -> not? greater? to :attribute "a" to :attribute "b"
     passed

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -3865,7 +3865,7 @@ do [
     
     topic « greaterOrEqual? - :attributelabel
     
-    ; ensure -> greaterOrEqual? to :attributelabel "b" to :attributelabel "a"
+    ensure -> greaterOrEqual? to :attributelabel "b" to :attributelabel "a"
     ensure -> greaterOrEqual? to :attributelabel "a" to :attributelabel "a"
     ensure -> greaterOrEqual? to :attributelabel "b" to :attributelabel "b"
     ensure -> not? greaterOrEqual? to :attributelabel "a" to :attributelabel "b"

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -3840,7 +3840,7 @@ do [
     
     topic « greaterOrEqual? - :attribute
     
-    ; ensure -> greaterOrEqual? to :attribute "b" to :attribute "a"
+    ensure -> greaterOrEqual? to :attribute "b" to :attribute "a"
     ensure -> greaterOrEqual? to :attribute "a" to :attribute "a"
     ensure -> greaterOrEqual? to :attribute "b" to :attribute "b"
     ensure -> not? greaterOrEqual? to :attribute "a" to :attribute "b"

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -6260,7 +6260,7 @@ do [
     
     topic « lessOrEqual? - :attributelabel
     
-    ; ensure -> lessOrEqual? to :attributelabel "a" to :attributelabel "b"
+    ensure -> lessOrEqual? to :attributelabel "a" to :attributelabel "b"
     ensure -> lessOrEqual? to :attributelabel "a" to :attributelabel "a"
     ensure -> lessOrEqual? to :attributelabel "b" to :attributelabel "b"
     ensure -> not? lessOrEqual? to :attributelabel "b" to :attributelabel "a"

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -5031,7 +5031,7 @@ do [
     
     topic « less? - :attribute
     
-    ; ensure -> less? to :attribute "a" to :attribute "b"
+    ensure -> less? to :attribute "a" to :attribute "b"
     ensure -> not? less? to :attribute "a" to :attribute "a"
     ensure -> not? less? to :attribute "b" to :attribute "b"
     ensure -> not? less? to :attribute "b" to :attribute "a"

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -534,8 +534,8 @@ do [
     topic « between? - :attribute
     
     ensure -> between? to :attribute "C" to :attribute "Arturo" to :attribute "Ruby"
-    ; ensure -> not? between? to :attribute "C" to :attribute "Arturo" to :attribute "Barry"
-    ; ensure -> not? between? to :attribute "C" to :attribute "Python" to :attribute "Ruby"
+    ensure -> not? between? to :attribute "C" to :attribute "Arturo" to :attribute "Barry"
+    ensure -> not? between? to :attribute "C" to :attribute "Python" to :attribute "Ruby"
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -6235,7 +6235,7 @@ do [
     
     topic « lessOrEqual? - :attribute
     
-    ; ensure -> lessOrEqual? to :attribute "a" to :attribute "b"
+    ensure -> lessOrEqual? to :attribute "a" to :attribute "b"
     ensure -> lessOrEqual? to :attribute "a" to :attribute "a"
     ensure -> lessOrEqual? to :attribute "b" to :attribute "b"
     ensure -> not? lessOrEqual? to :attribute "b" to :attribute "a"

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -5034,7 +5034,7 @@ do [
     ; ensure -> less? to :attribute "a" to :attribute "b"
     ensure -> not? less? to :attribute "a" to :attribute "a"
     ensure -> not? less? to :attribute "b" to :attribute "b"
-    ensure -> not? greaterOrEqual? to :attribute "b" to :attribute "a"
+    ensure -> not? less? to :attribute "b" to :attribute "a"
     passed
     
     ensure -> not? less? to :attribute "a" "b"


### PR DESCRIPTION
# Description

This PR fix [Comparison\between?], [Comparison\greater?], [Comparison\greaterOrEqual?], [Comparison\less?] [Comparison\lessOrEqual?] and [Comparison\compare] behavior for `:attribute` and `:attributelabel`, adding proper support to them.

- Fixes #1152
- Fixes #1151

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Add/Update unit-tests 