### PR TITLE
Add better comparison support for `:complex`

### DIFF
--- a/src/vm/values/comparison.nim
+++ b/src/vm/values/comparison.nim
@@ -199,14 +199,6 @@ proc `==`*(x: Value, y: Value): bool =
             else:
                 return false
 
-# TODO(VM/values/comparison) add `<`/`>` support for Complex values
-#  currently, `=` is supported but not `<` and `>`!
-#  Since Complex values encapsulate a VComplex object (from values/custom/vcomplex)
-#  the ideal implementation would be done there (adding a `>` and `<` operator to VComplex)
-#  and then link the method here :-)
-#  see also: https://github.com/arturo-lang/arturo/pull/1139
-#  labels: critical,bug,values,easy
-
 # TODO(VM/values/comparison) how should we handle Dictionary values?
 #  right now, both `<` and `>` simply return false
 #  but is it even a normal idea to compare a Dictionary with something else, or

--- a/src/vm/values/comparison.nim
+++ b/src/vm/values/comparison.nim
@@ -345,6 +345,11 @@ proc `<`*(x: Value, y: Value): bool {.inline.}=
         case x.kind:
             of Null: return false
             of Logical: return false
+            of Complex:
+                if x.z.re == y.z.re:
+                    return x.z.im < y.z.im
+                else:
+                    return x.z.re < y.z.re
             of Version: return x.version < y.version
             of Type: return false
             of Char: return $(x.c) < $(y.c)
@@ -435,6 +440,11 @@ proc `>`*(x: Value, y: Value): bool {.inline.}=
         case x.kind:
             of Null: return false
             of Logical: return false
+            of Complex:
+                if x.z.re == y.z.re:
+                    return x.z.im > y.z.im
+                else:
+                    return x.z.re > y.z.re
             of Version: return x.version > y.version
             of Type: return false
             of Char: return $(x.c) > $(y.c)

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2488,18 +2488,24 @@ do [
     
     topic « greater? - :complex
     
-    ; ensure -> greater? to :complex [1 1] to :complex [0 1]
-    ensure -> not? greater? to :complex [0 2] ((to :complex [1 2]) - 1) 
+    ensure -> greater? to :complex [2 2] to :complex [1 2]
+    ensure -> greater? to :complex [1 3] to :complex [1 2]
+    ensure -> (to :complex [2 2]) > (to :complex [1 2])
+    ensure -> (to :complex [1 2]) > (to :complex [1 3])
     passed
     
-    ensure -> not? greater? to :complex [1 2] to :complex @[neg 1 2] 
-    ensure -> not? greater? to :complex [1 2] 1
-    ensure -> not? greater? 1 to :complex [1 2]
-    ensure -> not? (to :complex [0 2]) > ((to :complex [1 2]) - 1) 
-    ensure -> not? (to :complex [1 2]) > to :complex @[neg 1 2] 
-    ensure -> not? (to :complex [1 2]) > 1
-    ensure -> not? 1 > to :complex [1 2]
+    ; equal to
+    ensure -> not? greater? to :complex [1 2] to :complex [1 2] 
+    ensure -> not? (to :complex [1 2]) > (to :complex [1 2]) 
     passed
+    
+    ; less than
+    ensure -> not? greater? to :complex [0 2] to :complex [1 2] 
+    ensure -> not? greater? to :complex [1 1] to :complex [1 2]
+    ensure -> not? (to :complex [0 2]) > (to :complex [1 2]) 
+    ensure -> not? (to :complex [1 1]) > (to :complex [1 2])
+    passed
+    
     
     topic « greater? - :version
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -7215,16 +7215,22 @@ do [
     
     topic « notEqual? - :complex
     
-    ensure -> not? notEqual? to :complex [0 2] ((to :complex [1 2]) - 1) 
+    ensure -> not? notEqual? to :complex [0 2] to :complex [0 2]
+    ensure -> not? (to :complex [0 2]) <> (to :complex [0 2])
     passed
     
-    ensure -> notEqual? to :complex [1 2] to :complex @[neg 1 2] 
-    ensure -> notEqual? to :complex [1 2] 1
-    ensure -> notEqual? 1 to :complex [1 2]
-    ensure -> not? (to :complex [0 2]) <> ((to :complex [1 2]) - 1) 
-    ensure -> (to :complex [1 2]) <> to :complex @[neg 1 2] 
-    ensure -> (to :complex [1 2]) <> 1
-    ensure -> 1 <> to :complex [1 2]
+    ; greater than
+    ensure -> notEqual? to :complex [2 2] to :complex [1 2] 
+    ensure -> notEqual? to :complex [2 3] to :complex [1 2]
+    ensure -> (to :complex [2 2]) <> (to :complex [1 2]) 
+    ensure -> (to :complex [2 3]) <> (to :complex [1 2]) 
+    passed
+    
+    ; less than
+    ensure -> notEqual? to :complex [0 2] to :complex [1 2] 
+    ensure -> notEqual? to :complex [0 1] to :complex [1 2]
+    ensure -> (to :complex [0 2]) <> (to :complex [1 2]) 
+    ensure -> (to :complex [0 1]) <> (to :complex [1 2])
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -8276,12 +8276,17 @@ do [
     
     topic « same? - :complex
     
-    ensure -> same? to :complex [0 2] ((to :complex [1 2]) - 1) 
+    ensure -> same? to :complex [0 2] to :complex [0 2]
     passed
     
-    ensure -> not? same? to :complex [1 2] to :complex @[neg 1 2] 
-    ensure -> not? same? to :complex [1 2] 1
-    ensure -> not? same? 1 to :complex [1 2]
+    ; greater than
+    ensure -> not? same? to :complex [2 2] to :complex [1 2] 
+    ensure -> not? same? to :complex [2 3] to :complex [1 2]
+    passed
+    
+    ; less than
+    ensure -> not? same? to :complex [0 2] to :complex [1 2] 
+    ensure -> not? same? to :complex [0 1] to :complex [1 2]
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -6061,16 +6061,23 @@ do [
     
     topic « lessOrEqual? - :complex
     
-    ensure -> lessOrEqual? to :complex [0 2] ((to :complex [1 2]) - 1) 
+    ; greater than
+    ensure -> lessOrEqual? to :complex [0 2] to :complex [1 2] 
+    ensure -> lessOrEqual? to :complex [1 1] to :complex [1 2]
+    ensure -> (to :complex [0 2]) =< (to :complex [1 2]) 
+    ensure -> (to :complex [1 1]) =< (to :complex [1 2])
     passed
     
-    ensure -> not? lessOrEqual? to :complex [1 2] to :complex @[neg 1 2] 
-    ensure -> not? lessOrEqual? to :complex [1 2] 1
-    ensure -> not? lessOrEqual? 1 to :complex [1 2]
-    ensure -> (to :complex [0 2]) =< ((to :complex [1 2]) - 1) 
-    ensure -> not? (to :complex [1 2]) =< to :complex @[neg 1 2] 
-    ensure -> not? (to :complex [1 2]) =< 1
-    ensure -> not? 1 =< to :complex [1 2]
+    ; equal to
+    ensure -> lessOrEqual? to :complex [1 2] to :complex [1 2] 
+    ensure -> (to :complex [1 2]) =< (to :complex [1 2]) 
+    passed
+    
+    ; less than
+    ensure -> not? lessOrEqual? to :complex [2 2] to :complex [1 2]
+    ensure -> not? lessOrEqual? to :complex [1 3] to :complex [1 2]
+    ensure -> not? (to :complex [2 2]) =< (to :complex [1 2])
+    ensure -> not? (to :complex [1 3]) =< (to :complex [1 2])
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -1323,7 +1323,7 @@ do [
     topic « equal? - :complex
     
     ensure -> equal? to :complex [0 2] to :complex [0 2]
-    ensure -> equal? (to :complex [0 2]) = (to :complex [0 2])
+    ensure -> (to :complex [0 2]) = (to :complex [0 2])
     passed
     
     ; greater than

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -2491,7 +2491,7 @@ do [
     ensure -> greater? to :complex [2 2] to :complex [1 2]
     ensure -> greater? to :complex [1 3] to :complex [1 2]
     ensure -> (to :complex [2 2]) > (to :complex [1 2])
-    ensure -> (to :complex [1 2]) > (to :complex [1 3])
+    ensure -> (to :complex [1 3]) > (to :complex [1 2])
     passed
     
     ; equal to
@@ -3656,7 +3656,7 @@ do [
     ensure -> greaterOrEqual? to :complex [2 2] to :complex [1 2]
     ensure -> greaterOrEqual? to :complex [1 3] to :complex [1 2]
     ensure -> (to :complex [2 2]) >= (to :complex [1 2])
-    ensure -> (to :complex [1 2]) >= (to :complex [1 3])
+    ensure -> (to :complex [1 3]) >= (to :complex [1 2])
     passed
     
     ; equal to

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -3661,14 +3661,14 @@ do [
     
     ; equal to
     ensure -> greaterOrEqual? to :complex [1 2] to :complex [1 2] 
-    ensure -> (to :complex [1 2]) > (to :complex [1 2]) 
+    ensure -> (to :complex [1 2]) >= (to :complex [1 2]) 
     passed
     
     ; less than
     ensure -> not? greaterOrEqual? to :complex [0 2] to :complex [1 2] 
     ensure -> not? greaterOrEqual? to :complex [1 1] to :complex [1 2]
-    ensure -> not? (to :complex [0 2]) > (to :complex [1 2]) 
-    ensure -> not? (to :complex [1 1]) > (to :complex [1 2])
+    ensure -> not? (to :complex [0 2]) >= (to :complex [1 2]) 
+    ensure -> not? (to :complex [1 1]) >= (to :complex [1 2])
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -3652,17 +3652,23 @@ do [
     
     topic « greaterOrEqual? - :complex
     
-    ; ensure -> greaterOrEqual? to :complex [1 2] to :complex [0 2]
-    ensure -> greaterOrEqual? to :complex [0 2] ((to :complex [1 2]) - 1) 
+    ; greater than
+    ensure -> greaterOrEqual? to :complex [2 2] to :complex [1 2]
+    ensure -> greaterOrEqual? to :complex [1 3] to :complex [1 2]
+    ensure -> (to :complex [2 2]) >= (to :complex [1 2])
+    ensure -> (to :complex [1 2]) >= (to :complex [1 3])
     passed
     
-    ensure -> not? greaterOrEqual? to :complex [1 2] to :complex @[neg 1 2] 
-    ensure -> not? greaterOrEqual? to :complex [1 2] 1
-    ensure -> not? greaterOrEqual? 1 to :complex [1 2]
-    ensure -> (to :complex [0 2]) >= ((to :complex [1 2]) - 1) 
-    ensure -> not? (to :complex [1 2]) >= to :complex @[neg 1 2] 
-    ensure -> not? (to :complex [1 2]) >= 1
-    ensure -> not? 1 >= to :complex [1 2]
+    ; equal to
+    ensure -> greaterOrEqual? to :complex [1 2] to :complex [1 2] 
+    ensure -> (to :complex [1 2]) > (to :complex [1 2]) 
+    passed
+    
+    ; less than
+    ensure -> not? greaterOrEqual? to :complex [0 2] to :complex [1 2] 
+    ensure -> not? greaterOrEqual? to :complex [1 1] to :complex [1 2]
+    ensure -> not? (to :complex [0 2]) > (to :complex [1 2]) 
+    ensure -> not? (to :complex [1 1]) > (to :complex [1 2])
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -857,9 +857,16 @@ do [
     
     topic « compare - :complex
     
-    ensure -> 0 = compare to :complex [0 2] ((to :complex [1 2]) - 1)
-    ; ensure -> 1 = compare to :complex [1 2] to :complex [0 2] 
-    ; ensure -> (neg 1) = compare to :complex [0 2] to :complex [1 2] 
+    ; comparing re
+    ensure -> 0 = compare to :complex [1 2] to :complex [1 2]
+    ensure -> 1 = compare to :complex [1 2] to :complex [1 2] 
+    ensure -> (neg 1) = compare to :complex [1 2] to :complex [2 2] 
+    passed
+    
+    ; comparing im
+    ensure -> 0 = compare to :complex [1 2] to :complex [1 2]
+    ensure -> 1 = compare to :complex [1 2] to :complex [1 1] 
+    ensure -> (neg 1) = compare to :complex [1 1] to :complex [1 2] 
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -4880,18 +4880,24 @@ do [
     
     
     topic « less? - :complex
-    ; always returns `false`
     
-    ensure -> not? less? to :complex [0 2] ((to :complex [1 2]) - 1) 
+    ; less
+    ensure -> less? to :complex [0 2] to :complex [1 2] 
+    ensure -> less? to :complex [1 1] to :complex [1 2]
+    ensure -> (to :complex [0 2]) < (to :complex [1 2]) 
+    ensure -> (to :complex [1 1]) < (to :complex [1 2])
     passed
     
-    ensure -> not? less? to :complex [1 2] to :complex @[neg 1 2] 
-    ensure -> not? less? to :complex [1 2] 1
-    ensure -> not? less? 1 to :complex [1 2]
-    ensure -> not? (to :complex [0 2]) < ((to :complex [1 2]) - 1) 
-    ensure -> not? (to :complex [1 2]) < to :complex @[neg 1 2] 
-    ensure -> not? (to :complex [1 2]) < 1
-    ensure -> not? 1 < to :complex [1 2]
+    ; equal to
+    ensure -> not? less? to :complex [1 2] to :complex [1 2] 
+    ensure -> not? (to :complex [1 2]) < (to :complex [1 2]) 
+    passed
+    
+    ; less than
+    ensure -> not? less? to :complex [2 2] to :complex [1 2]
+    ensure -> not? less? to :complex [1 3] to :complex [1 2]
+    ensure -> not? (to :complex [2 2]) < (to :complex [1 2])
+    ensure -> not? (to :complex [1 3]) < (to :complex [1 2])
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -477,9 +477,18 @@ do [
     
     topic « between? - :complex
     
+    ; comparing re
     ensure -> between? to :complex [1 2] to :complex [0 2] to :complex [2 2]
-    ; ensure -> not? between? to :complex [3 2] to :complex [1 2] to :complex [2 2] 
-    ; ensure -> not? between? to :complex [0 2] to :complex [1 2] to :complex [2 2] 
+    ensure -> between? to :complex [1 2] to :complex [1 2] to :complex [2 2]
+    ensure -> not? between? to :complex [0 2] to :complex [1 2] to :complex [2 2]
+    ensure -> not? between? to :complex [3 2] to :complex [0 2] to :complex [1 2]
+    passed
+    
+    ; comparing im
+    ensure -> between? to :complex [1 1] to :complex [1 0] to :complex [1 2]
+    ensure -> between? to :complex [1 1] to :complex [1 1] to :complex [1 2]
+    ensure -> not? between? to :complex [1 0] to :complex [1 1] to :complex [1 2]
+    ensure -> not? between? to :complex [1 3] to :complex [1 0] to :complex [1 2]
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -1322,16 +1322,22 @@ do [
     
     topic « equal? - :complex
     
-    ensure -> equal? to :complex [0 2] ((to :complex [1 2]) - 1) 
+    ensure -> equal? to :complex [0 2] to :complex [0 2]
+    ensure -> equal? (to :complex [0 2]) = (to :complex [0 2])
     passed
     
-    ensure -> not? equal? to :complex [1 2] to :complex @[neg 1 2] 
-    ensure -> not? equal? to :complex [1 2] 1
-    ensure -> not? equal? 1 to :complex [1 2]
-    ensure -> (to :complex [0 2]) = ((to :complex [1 2]) - 1) 
-    ensure -> not? (to :complex [1 2]) = to :complex @[neg 1 2] 
-    ensure -> not? (to :complex [1 2]) = 1
-    ensure -> not? 1 = to :complex [1 2]
+    ; greater than
+    ensure -> not? equal? to :complex [2 2] to :complex [1 2] 
+    ensure -> not? equal? to :complex [2 3] to :complex [1 2]
+    ensure -> not? (to :complex [2 2]) = (to :complex [1 2]) 
+    ensure -> not? (to :complex [2 3]) = (to :complex [1 2]) 
+    passed
+    
+    ; less than
+    ensure -> not? equal? to :complex [0 2] to :complex [1 2] 
+    ensure -> not? equal? to :complex [0 1] to :complex [1 2]
+    ensure -> not? (to :complex [0 2]) = (to :complex [1 2]) 
+    ensure -> not? (to :complex [0 1]) = (to :complex [1 2])
     passed
     
     

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -859,7 +859,7 @@ do [
     
     ; comparing re
     ensure -> 0 = compare to :complex [1 2] to :complex [1 2]
-    ensure -> 1 = compare to :complex [1 2] to :complex [1 2] 
+    ensure -> 1 = compare to :complex [2 2] to :complex [1 2] 
     ensure -> (neg 1) = compare to :complex [1 2] to :complex [2 2] 
     passed
     

--- a/tests/unittests/lib.comparison.res
+++ b/tests/unittests/lib.comparison.res
@@ -55,6 +55,7 @@
 
 >> between? - :complex
 [+] passed!
+[+] passed!
 
 >> between? - :version
 [+] passed!
@@ -126,6 +127,7 @@
 [+] passed!
 
 >> compare - :complex
+[+] passed!
 [+] passed!
 
 >> compare - :version
@@ -227,6 +229,7 @@
 [+] passed!
 
 >> equal? - :complex
+[+] passed!
 [+] passed!
 [+] passed!
 
@@ -393,6 +396,7 @@
 >> greater? - :complex
 [+] passed!
 [+] passed!
+[+] passed!
 
 >> greater? - :version
 [+] passed!
@@ -551,6 +555,7 @@
 [+] passed!
 
 >> greaterOrEqual? - :complex
+[+] passed!
 [+] passed!
 [+] passed!
 
@@ -715,6 +720,7 @@
 >> less? - :complex
 [+] passed!
 [+] passed!
+[+] passed!
 
 >> less? - :version
 [+] passed!
@@ -877,6 +883,7 @@
 >> lessOrEqual? - :complex
 [+] passed!
 [+] passed!
+[+] passed!
 
 >> lessOrEqual? - :version
 [+] passed!
@@ -1028,6 +1035,7 @@
 [+] passed!
 
 >> notEqual? - :complex
+[+] passed!
 [+] passed!
 [+] passed!
 
@@ -1186,6 +1194,7 @@
 [+] passed!
 
 >> same? - :complex
+[+] passed!
 [+] passed!
 [+] passed!
 


### PR DESCRIPTION
# Description

`:complex` types for now can be compared if they are _equal_, but the same is not real for _less_ or _greater_ comparisons,
So I'm adding this support.

Fixes #1150

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Add/Update unit-tests