### PR TITLE
[`Numbers\{ceil,floor,round}`]: add support to `:rational` values

### DIFF
--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -751,7 +751,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the largest integer not greater than given value",
         args        = {
-            "value" : {Integer,Floating}
+            "value" : {Integer,Floating,Rational}
         },
         attrs       = NoAttrs,
         returns     = {Integer},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -756,10 +756,11 @@ proc defineSymbols*() =
         attrs       = NoAttrs,
         returns     = {Integer},
         example     = """
-            print floor 2.1         ; 2
-            print floor 2.9         ; 2
-            print floor neg 3.5     ; -4
-            print floor 4           ; 4
+            print floor 2.1                     ; 2
+            print floor 2.9                     ; 2
+            print floor neg 3.5                 ; -4
+            print floor 4                       ; 4
+            print floor to :rational @[neg 7 2] ; -4
         """:
             #=======================================================
             push(newInteger(int(floor(asFloat(x)))))

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -55,7 +55,7 @@ template processTrigonometric(fun: untyped): untyped =
 #  labels:library, new feature
 
 # TODO(Numbers) add support to `:rational`to necessary functions
-#   labels: library, new feature, open discussion
+#   labels:library, new feature, open discussion
  
 proc defineSymbols*() =
 

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -53,6 +53,9 @@ template processTrigonometric(fun: untyped): untyped =
 
 # TODO(Numbers) add `tau` constant
 #  labels:library, new feature
+
+# TODO(Numbers) add support to `:rational`to necessary functions
+#   labels: library, new feature, open discussion
  
 proc defineSymbols*() =
 

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -1225,9 +1225,13 @@ proc defineSymbols*() =
         },
         returns     = {Floating},
         example     = """
-            print round 2.1         ; 2.0
-            print round 2.9         ; 3.0
-            print round 6           ; 6.0
+            print round 2.1                     ; 2.0
+            print round 2.9                     ; 3.0
+            print round 6                       ; 6.0
+
+            print round to :rational [29 10]    ; 3.0
+            print round to :rational [21 10]    ; 2.0
+            print round to :rational [5 2]      ; 3.0
 
             print round pi          ; 3.0
             ..........

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -1218,7 +1218,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "round given value",
         args        = {
-            "value" : {Integer,Floating}
+            "value" : {Integer,Floating,Rational}
         },
         attrs       = {
             "to"    : ({Integer},"round to given decimal places")

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -385,10 +385,11 @@ proc defineSymbols*() =
         attrs       = NoAttrs,
         returns     = {Integer},
         example     = """
-            print ceil 2.1          ; 3
-            print ceil 2.9          ; 3
-            print ceil neg 3.5      ; -3
-            print ceil 4            ; 4
+            print ceil 2.1                      ; 3
+            print ceil 2.9                      ; 3
+            print ceil neg 3.5                  ; -3
+            print ceil 4                        ; 4
+            print ceil to :rational @[neg 7 2]  ; -3
         """:
             #=======================================================
             push(newInteger(int(ceil(asFloat(x)))))

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -380,7 +380,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the smallest integer not smaller than given value",
         args        = {
-            "value" : {Integer,Floating}
+            "value" : {Integer,Floating,Rational}
         },
         attrs       = NoAttrs,
         returns     = {Integer},

--- a/src/vm/values/value.nim
+++ b/src/vm/values/value.nim
@@ -687,11 +687,17 @@ func asFloat*(v: Value): float {.enforceNoRaises.} =
     ## get numeric value forcefully as a float
     ## 
     ## **Hint:** We have to make sure the value is 
-    ## either an Integer or a Floating value
-    if v.kind == Floating:
+    ## either an Integer, a Floating or a Rational value
+    case v.kind
+    of Floating:
         result = v.f
-    else:
+    of Integer:
         result = float(v.i)
+    of Rational:
+        result = toFloat(v.rat)
+    else:
+        discard
+
 
 func asInt*(v: Value): int {.enforceNoRaises.} = 
     ## get numeric value forcefully as an int

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -85,3 +85,26 @@ do [
     passed
     
 ]
+
+
+topic « round
+do [
+    
+    ensure.that: "works with :floating"          -> 2.0       = round 2.1                    
+    ensure.that: "works with :floating"          -> 3.0       = round 2.9                    
+    ensure.that: "works with negative :floating" -> (neg 4.0) = round neg 3.5
+    passed
+                   
+    ensure.that: "works with :integer"          -> 4       = round 4
+    ensure.that: "works with negative :integer" -> (neg 4) = round neg 4
+    passed
+
+    ensure.that: "works with :rational" -> 4       = round to :rational @[7 2]
+    ensure.that: "works with :rational" -> 3       = round to :rational @[29 10]
+    ensure.that: "works with :rational" -> 2       = round to :rational @[21 10]
+    ensure.that: "works with :rational" -> (neg 4) = round to :rational @[neg 7 2]
+    ensure.that: "works with :rational" -> (neg 3) = round to :rational @[neg 29 10]
+    ensure.that: "works with :rational" -> (neg 2) = round to :rational @[neg 21 10]
+    passed
+    
+]

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -14,9 +14,9 @@ do [
     passed
                         
     ensure.that: "works with :rational"
-        -> 4   = ceil to :rational @[7 2]
+        -> 4 = ceil to :rational @[7 2]
     ensure.that: "works with negative :rational" 
-        -> (neg 3)   = ceil to :rational @[neg 7 2]
+        -> (neg 3) = ceil to :rational @[neg 7 2]
     passed
     
 ]

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -131,4 +131,20 @@ do [
     ensure.that: "works with :rational" -> (neg 2) = round to :rational @[neg 21 10]
     passed
     
+    ensure.that: "always returns :floating" -> every? @[
+        round 2.1
+        round 2.9
+        round 3.5
+        round neg 3.5
+        round 4
+        round neg 4
+        round to :rational @[7 2]
+        round to :rational @[neg 7 2]
+        round to :rational @[29 10]
+        round to :rational @[neg 29 10]
+        round to :rational @[21 10]
+        round to :rational @[neg 21 10]
+    ] => floating? 
+    passed
+    
 ]

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -19,6 +19,18 @@ do [
         -> (neg 3) = ceil to :rational @[neg 7 2]
     passed
     
+    ensure.that: "always returns :integer" -> every? @[
+        ceil 2.1
+        ceil 2.9
+        ceil 3.5
+        ceil neg 3.5
+        ceil 4
+        ceil neg 4
+        ceil to :rational @[7 2]
+        ceil to :rational @[neg 7 2]
+    ] => integer? 
+    passed
+    
 ]
 
 topic « clamp

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -96,6 +96,18 @@ do [
         -> (neg 4) = floor to :rational @[neg 7 2]
     passed
     
+    ensure.that: "always returns :integer" -> every? @[
+        floor 2.1
+        floor 2.9
+        floor 3.5
+        floor neg 3.5
+        floor 4
+        floor neg 4
+        floor to :rational @[7 2]
+        floor to :rational @[neg 7 2]
+    ] => integer? 
+    passed
+    
 ]
 
 

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -65,3 +65,23 @@ do [
     passed
     
 ]
+
+topic « floor
+do [
+    
+    ensure.that: "works with :floating"          -> 2       = floor 2.1                    
+    ensure.that: "works with :floating"          -> 2       = floor 2.9                    
+    ensure.that: "works with negative :floating" -> (neg 4) = floor neg 3.5
+    passed
+                   
+    ensure.that: "works with :integer"          -> 4       = floor 4
+    ensure.that: "works with negative :integer" -> (neg 4) = floor neg 4
+    passed
+                        
+    ensure.that: "works with :rational"
+        -> 3 = floor to :rational @[7 2]
+    ensure.that: "works with negative :rational" 
+        -> (neg 4) = floor to :rational @[neg 7 2]
+    passed
+    
+]

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -1,6 +1,26 @@
 topic: $[topic :string] -> print ~"\n>> |topic|"
 passed: $[] -> print "[+] passed!"
 
+topic « ceil
+do [
+    
+    ensure.that: "works with :floating"          -> 3       = ceil 2.1                    
+    ensure.that: "works with :floating"          -> 3       = ceil 2.9                    
+    ensure.that: "works with negative :floating" -> (neg 3) = ceil neg 3.5
+    passed
+                   
+    ensure.that: "works with :integer"          -> 4       = ceil 4
+    ensure.that: "works with negative :integer" -> (neg 4) = ceil neg 4
+    passed
+                        
+    ensure.that: "works with :rational"
+        -> 4   = ceil to :rational @[7 2]
+    ensure.that: "works with negative :rational" 
+        -> (neg 3)   = ceil to :rational @[neg 7 2]
+    passed
+    
+]
+
 topic « clamp
 do [
     

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -76,6 +76,35 @@ do [
     ] => throws?
     passed
     
+    ensure.that: 
+    "returns :integer for :integer parameter" 
+    -> true
+    loop @[
+        clamp 5 0..10    
+        clamp 5 6..10    
+        clamp 5 0..4      
+    ] => integer?
+    passed
+    
+    ensure.that: 
+    "returns :integer for :floating parameter that is outside the range" 
+    -> true
+    loop @[  
+        clamp 5.0 6..10    
+        clamp 5.0 0..4       
+        clamp 5.5 6..10    
+        clamp 5.5 0..4      
+    ] => integer?
+    passed
+
+    ensure.that: 
+    "returns :floating for :floating parameter that is already within the rang" 
+    -> every? @[
+        clamp 5.0 0..10    
+        clamp 5.5 0..10 
+    ] => floating?
+    passed
+    
 ]
 
 topic « floor

--- a/tests/unittests/lib.numbers.res
+++ b/tests/unittests/lib.numbers.res
@@ -1,4 +1,9 @@
 
+>> ceil
+[+] passed!
+[+] passed!
+[+] passed!
+
 >> clamp
 [+] passed!
 [+] passed!
@@ -6,6 +11,11 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+
+>> floor
 [+] passed!
 [+] passed!
 [+] passed!

--- a/tests/unittests/lib.numbers.res
+++ b/tests/unittests/lib.numbers.res
@@ -3,6 +3,7 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
 
 >> clamp
 [+] passed!
@@ -14,8 +15,18 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
 
 >> floor
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+
+>> round
+[+] passed!
 [+] passed!
 [+] passed!
 [+] passed!


### PR DESCRIPTION
# Description

At the moment, `ceil`, `floor` and `round` just work with `:integer`s and `:floating`s, so I'm adding support to `:rational` values...

## Result

```red
ceil to :rational @[7 2] 
; => 4
ceil to :rational @[neg 7 2] 
; => -3
floor to :rational @[7 2]     
; => 3
floor to :rational @[neg 7 2] 
; => -4
round to :rational @[21 10]
; => 2
round to :rational @[neg 7 2]
; => -4
```

> Just a minor detail, I added some more unit-tests to `Numbers\clamp` too. :)

## Related
[Suggested by Krenium on Discord][discord-message]

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Add/Update documentation's examples
- [x] Add/Update unit-tests
- [x] This change requires a documentation update

[discord-message]: https://discord.com/channels/765519132186640445/829324913097048065/1105639192626745474