### PR TITLE
[Numbers\clamp]: add support for more types

### DIFF
--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -404,11 +404,11 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "force value within given range",
         args        = {
-            "number" : {Integer, Floating},
+            "number" : {Integer, Floating, Rational},
             "range"  : {Range}
         },
         attrs       = NoAttrs,
-        returns     = {Integer, Floating},
+        returns     = {Integer, Floating, Rational},
         example     = """
             clamp 2 1..3                ; 2
             clamp 0 1..3                ; 1

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -408,7 +408,7 @@ proc defineSymbols*() =
             "range"  : {Range}
         },
         attrs       = NoAttrs,
-        returns     = {Integer, Floating, Rational},
+        returns     = {Integer, Floating},
         example     = """
             clamp 2 1..3                ; 2
             clamp 0 1..3                ; 1
@@ -420,9 +420,14 @@ proc defineSymbols*() =
             if not y.rng.numeric:
                 RuntimeError_IncompatibleValueType("clamp", valueKind(y), "numeric range")
             
-            if (let minElem = y.rng.min()[1]; x.asFloat < float(minElem.i)): push(minElem)
-            elif (let maxElem = y.rng.max()[1]; x.asFloat > float(maxElem.i)): push(maxElem)
-            else: push(x)
+            if x.kind == Integer:
+                if (let minElem = y.rng.min()[1]; x.i < minElem.i): push(minElem)
+                elif (let maxElem = y.rng.max()[1]; x.i > maxElem.i): push(maxElem)
+                else: push(x)
+            else:
+                if (let minElem = y.rng.min()[1]; x.f < float(minElem.i)): push(minElem)
+                elif (let maxElem = y.rng.max()[1]; x.f > float(maxElem.i)): push(maxElem)
+                else: push(x)
              
 
     builtin "conj",

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -408,7 +408,7 @@ proc defineSymbols*() =
             "range"  : {Range}
         },
         attrs       = NoAttrs,
-        returns     = {Integer, Floating},
+        returns     = {Integer, Floating, Rational},
         example     = """
             clamp 2 1..3                ; 2
             clamp 0 1..3                ; 1
@@ -420,14 +420,9 @@ proc defineSymbols*() =
             if not y.rng.numeric:
                 RuntimeError_IncompatibleValueType("clamp", valueKind(y), "numeric range")
             
-            if x.kind == Integer:
-                if (let minElem = y.rng.min()[1]; x.i < minElem.i): push(minElem)
-                elif (let maxElem = y.rng.max()[1]; x.i > maxElem.i): push(maxElem)
-                else: push(x)
-            else:
-                if (let minElem = y.rng.min()[1]; x.f < float(minElem.i)): push(minElem)
-                elif (let maxElem = y.rng.max()[1]; x.f > float(maxElem.i)): push(maxElem)
-                else: push(x)
+            if (let minElem = y.rng.min()[1]; x.asFloat < float(minElem.i)): push(minElem)
+            elif (let maxElem = y.rng.max()[1]; x.asFloat > float(maxElem.i)): push(maxElem)
+            else: push(x)
              
 
     builtin "conj",

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -410,11 +410,19 @@ proc defineSymbols*() =
         attrs       = NoAttrs,
         returns     = {Integer, Floating, Rational},
         example     = """
-            clamp 2 1..3                ; 2
-            clamp 0 1..3                ; 1
-            clamp 4 1..3                ; 3
-            clamp 4 3..1                ; 3
-            clamp 5 range.step: 2 0 5   ; 4
+            clamp 2 1..3                        ; 2
+            clamp 0 1..3                        ; 1
+            clamp 4 1..3                        ; 3
+            clamp 4 3..1                        ; 3
+            clamp 5 range.step: 2 0 5           ; 4
+            
+            clamp 4.5 0..6                      ; 4.5
+            clamp to :rational [1 5] 0..1       ; 1/5
+            
+            clamp 4.5 [1 2.5]                   ; 2.5
+            clamp 2 [5 10]                      ; 5
+            clamp 2 [10 5]                      ; 5
+            clamp 2.5 @[1 to :rational [5 2]]   ; 2.5
         """:
             #=======================================================
             case y.kind

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -420,14 +420,9 @@ proc defineSymbols*() =
             if not y.rng.numeric:
                 RuntimeError_IncompatibleValueType("clamp", valueKind(y), "numeric range")
             
-            if x.kind == Integer:
-                if (let minElem = y.rng.min()[1]; x.i < minElem.i): push(minElem)
-                elif (let maxElem = y.rng.max()[1]; x.i > maxElem.i): push(maxElem)
-                else: push(x)
-            else:
-                if (let minElem = y.rng.min()[1]; x.f < float(minElem.i)): push(minElem)
-                elif (let maxElem = y.rng.max()[1]; x.f > float(maxElem.i)): push(maxElem)
-                else: push(x)
+            if (let minElem = y.rng.min()[1]; x.asFloat < float(minElem.i)): push(minElem)
+            elif (let maxElem = y.rng.max()[1]; x.asFloat > float(maxElem.i)): push(maxElem)
+            else: push(x)
              
 
     builtin "conj",

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -113,6 +113,50 @@ do [
     
     
     topic « clamp - :rational with :range
+    
+    a: to :rational [5 2]
+    b: to :rational [2 1]
+    
+    ensure.that: "is within"  -> a = clamp a 0..4
+    ensure.that: "is greater" -> 1 = clamp a 0..1
+    ensure.that: "is less"    -> 3 = clamp a 3..4
+    ensure.that: "is in the upper limit" -> 2 = clamp b 0..2 
+    ensure.that: "is in the lower limit" -> 2 = clamp b 2..4
+    
+    a: to :rational [5 1]
+    b: to :rational [1 1]
+    
+    ensure.that: "works with .step attribute" -> 
+        4 = clamp a range.step: 2 0 5
+    ensure.that: "works with descending range" -> 
+        5 = clamp a range.step: 2 5 0
+    ensure.that: "works with descending and stepped range" -> 
+        3 = clamp b range.step: 2 5 2
+    passed
+    
+    a: to :rational [5 1]
+    b: to :rational [11 2]
+    
+    ensure.that: {
+        returns :integer 
+        for :rational parameter that is outside the range
+    } -> every? @[  
+        clamp a 6..10    
+        clamp a 0..4       
+        clamp b 6..10    
+        clamp b 0..4      
+    ] => integer?
+    passed
+    
+    ensure.that: {
+        returns :rational 
+        for :rational parameter that is already within the range
+    } -> every? @[
+        clamp a 0..10    
+        clamp b 0..10 
+    ] => rational? 
+    passed
+    
     topic « clamp - :rational with [:integer]
     topic « clamp - :rational with [:floating]
     topic « clamp - :rational with [:rational] 

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -33,51 +33,29 @@ do [
     
 ]
 
+
 topic « clamp
 do [
     
-    ensure -> 1 = clamp 1 0..2
-    ensure -> 1 = clamp 1 2..0
+    
+    topic « clamp - :integer with :range
+    
+    ensure.that: "is within"  -> 2 = clamp 2 0..4
+    ensure.that: "is greater" -> 1 = clamp 2 0..1
+    ensure.that: "is less"    -> 3 = clamp 2 3..4
+    ensure.that: "is in the upper limit" -> 2 = clamp 2 0..2 
+    ensure.that: "is in the lower limit" -> 2 = clamp 2 2..4
+    
+    ensure.that: "works with .step attribute" -> 
+        4 = clamp 5 range.step: 2 0 5
+    ensure.that: "works with descending range" -> 
+        5 = clamp 5 range.step: 2 5 0
+    ensure.that: "works with descending and stepped range" -> 
+        3 = clamp 1 range.step: 2 5 2
     passed
     
-    ensure -> 1.5 = clamp 1.5 0..2
-    ensure -> 1.5 = clamp 1.5 2..0
-    passed
     
-    ensure -> 1 = clamp 2 0..1
-    ensure -> 1 = clamp 2 1..0
-    passed
-    
-    ensure -> 1 = clamp 2.5 0..1
-    ensure -> 1 = clamp 2.5 1..0
-    passed
-    
-    ensure -> 1 = clamp 0 1..2
-    ensure -> 1 = clamp 0 2..1
-    passed
-   
-    ensure -> 1 = clamp 0.5 1..2
-    ensure -> 1 = clamp 0.5 2..1
-    passed
-    
-    ensure -> 4 = clamp 5 range.step: 2 0 5
-    ensure -> 5 = clamp 5 range.step: 2 5 0
-    ensure -> 3 = clamp 1 range.step: 2 5 2
-    passed
-    
-    ensure -> 4 = clamp 5.5 range.step: 2 0 5
-    ensure -> 5 = clamp 5.5 range.step: 2 5 0
-    ensure -> 3 = clamp 1.2 range.step: 2 5 2
-    passed
-    
-    ensure -> every? @[
-        -> clamp 2 `a`..`d`
-        -> clamp `b` `a`..`c`
-    ] => throws?
-    passed
-    
-    ensure.that: 
-    "returns :integer for :integer parameter" 
+    ensure.that: "returns :integer for :integer parameter" 
     -> true
     loop @[
         clamp 5 0..10    
@@ -86,24 +64,67 @@ do [
     ] => integer?
     passed
     
-    ensure.that: 
-    "returns :integer for :floating parameter that is outside the range" 
-    -> true
-    loop @[  
+    
+    topic « clamp - :integer with [:integer]
+    topic « clamp - :integer with [:floating]
+    topic « clamp - :integer with [:rational]
+    
+    
+    topic « clamp - :floating with :range
+    
+    ensure.that: "is within"  -> 2.5 = clamp 2.5 0..4
+    ensure.that: "is greater" -> 1   = clamp 2.5 0..1
+    ensure.that: "is less"    -> 3   = clamp 2.5 3..4
+    ensure.that: "is in the upper limit" -> 2 = clamp 2.0 0..2 
+    ensure.that: "is in the lower limit" -> 2 = clamp 2.0 2..4
+    
+    ensure.that: "works with .step attribute" -> 
+        4 = clamp 5.0 range.step: 2 0 5
+    ensure.that: "works with descending range" -> 
+        5 = clamp 5.0 range.step: 2 5 0
+    ensure.that: "works with descending and stepped range" -> 
+        3 = clamp 1.0 range.step: 2 5 2
+    passed
+    
+    
+    ensure.that: {
+        returns :integer 
+        for :floating parameter that is outside the range
+    } -> every? @[  
         clamp 5.0 6..10    
         clamp 5.0 0..4       
         clamp 5.5 6..10    
         clamp 5.5 0..4      
     ] => integer?
     passed
-
-    ensure.that: 
-    "returns :floating for :floating parameter that is already within the rang" 
-    -> every? @[
+    
+    ensure.that: {
+        returns :floating 
+        for :floating parameter that is already within the range
+    } -> every? @[
         clamp 5.0 0..10    
         clamp 5.5 0..10 
-    ] => floating?
+    ] => floating? 
     passed
+    
+    topic « clamp - :floating with [:integer]
+    topic « clamp - :floating with [:floating]
+    topic « clamp - :floating with [:rational]
+    
+    
+    topic « clamp - :rational with :range
+    topic « clamp - :floating with [:integer]
+    topic « clamp - :floating with [:floating]
+    topic « clamp - :floating with [:rational] 
+    
+    
+    topic « clamp - invalid operations
+    
+    ensure -> every? @[
+        -> clamp 2 `a`..`d`
+        -> clamp `b` `a`..`c`
+    ] => throws? passed 
+    
     
 ]
 

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -38,136 +38,526 @@ topic « clamp
 do [
     
     
-    topic « clamp - :integer with :range
+    topic « clamp - returns the `number`
     
-    ensure.that: "is within"  -> 2 = clamp 2 0..4
-    ensure.that: "is greater" -> 1 = clamp 2 0..1
-    ensure.that: "is less"    -> 3 = clamp 2 3..4
-    ensure.that: "is in the upper limit" -> 2 = clamp 2 0..2 
-    ensure.that: "is in the lower limit" -> 2 = clamp 2 2..4
+        a: to :rational [4 2]
+        
+        ; :range
+        ensure -> 2   = clamp 2   0..4
+        ensure -> 2.0 = clamp 2.0 0..4
+        ensure -> a   = clamp a   0..4
+        passed
+        
+        ensure -> integer?  clamp 2   0..4
+        ensure -> floating? clamp 2.0 0..4
+        ensure -> rational? clamp a   0..4
+        passed
+        
+        ; [:integer :integer]
+        ensure -> 2   = clamp 2   [0 4]
+        ensure -> 2.0 = clamp 2.0 [0 4]
+        ensure -> a   = clamp a   [0 4]
+        passed
+        
+        ensure -> integer?  clamp 2   [0 4]
+        ensure -> floating? clamp 2.0 [0 4]
+        ensure -> rational? clamp a   [0 4]
+        passed
+        
+        ; [:floating :floating]
+        ensure -> 2   = clamp 2   [0.0 4.0]
+        ensure -> 2.0 = clamp 2.0 [0.0 4.0]
+        ensure -> a   = clamp a   [0.0 4.0]
+        passed
+        
+        ensure -> integer?  clamp 2   [0 4]
+        ensure -> floating? clamp 2.0 [0 4]
+        ensure -> rational? clamp a   [0 4]
+        passed
+        
+        ; [:rational :rational]
+        a: to :rational [0 1]
+        b: to :rational [4 1]
+        ensure -> 2   = clamp 2   @[a b]
+        ensure -> 2.0 = clamp 2.0 @[a b]
+        ensure -> a   = clamp a   @[a b]
+        passed
+        
+        ensure -> integer?  clamp 2   @[a b]
+        ensure -> floating? clamp 2.0 @[a b]
+        ensure -> rational? clamp a   @[a b]
+        passed
+        
+        ; [:integer :floating]
+        a: to :rational [0 1]
+        b: to :rational [4 1]
+        ensure -> 2   = clamp 2   @[0   4.0]
+        ensure -> 2.0 = clamp 2.0 @[0   4.0]
+        ensure -> a   = clamp a   @[0   4.0]
+        ensure -> 2   = clamp 2   @[0.0   4]
+        ensure -> 2.0 = clamp 2.0 @[0.0   4]
+        ensure -> a   = clamp a   @[0.0   4]
+        passed
+        
+        ensure -> integer?  clamp 2   @[0   4.0]
+        ensure -> floating? clamp 2.0 @[0   4.0]
+        ensure -> rational? clamp a   @[0   4.0]
+        ensure -> integer?  clamp 2   @[0.0   4]
+        ensure -> floating? clamp 2.0 @[0.0   4]
+        ensure -> rational? clamp a   @[0.0   4]
+        passed
+        
+        ; [:integer :rational]
+        a: to :rational [4 1]
+        b: to :rational [0 1]
+        ensure -> 2   = clamp 2   @[0 a]
+        ensure -> 2.0 = clamp 2.0 @[0 a]
+        ensure -> b   = clamp b   @[0 a]
+        ensure -> 2   = clamp 2   @[b 4]
+        ensure -> 2.0 = clamp 2.0 @[b 4]
+        ensure -> b   = clamp b   @[b 4]
+        passed
+        
+        ensure -> integer?  clamp 2   @[0 a]
+        ensure -> floating? clamp 2.0 @[0 a]
+        ensure -> rational? clamp b   @[0 a]
+        ensure -> integer?  clamp 2   @[b 4]
+        ensure -> floating? clamp 2.0 @[b 4]
+        ensure -> rational? clamp b   @[b 4]
+        passed
+        
+        ; [:floating :rational]
+        a: to :rational [4 1]
+        b: to :rational [0 1]
+        ensure -> 2   = clamp 2   @[0.0 a]
+        ensure -> 2.0 = clamp 2.0 @[0.0 a]
+        ensure -> b   = clamp b   @[0.0 a]
+        ensure -> 2   = clamp 2   @[b 4.0]
+        ensure -> 2.0 = clamp 2.0 @[b 4.0]
+        ensure -> b   = clamp b   @[b 4.0]
+        passed
+        
+        ensure -> integer?  clamp 2   @[0.0 a]
+        ensure -> floating? clamp 2.0 @[0.0 a]
+        ensure -> rational? clamp b   @[0.0 a]
+        ensure -> integer?  clamp 2   @[b 4.0]
+        ensure -> floating? clamp 2.0 @[b 4.0]
+        ensure -> rational? clamp b   @[b 4.0]
+        passed
     
-    ensure.that: "works with .step attribute" -> 
-        4 = clamp 5 range.step: 2 0 5
-    ensure.that: "works with descending range" -> 
-        5 = clamp 5 range.step: 2 5 0
-    ensure.that: "works with descending and stepped range" -> 
-        3 = clamp 1 range.step: 2 5 2
-    passed
     
+    topic « clamp - returns `range`'s upper edge
     
-    ensure.that: "returns :integer for :integer parameter" 
-    -> true
-    loop @[
-        clamp 5 0..10    
-        clamp 5 6..10    
-        clamp 5 0..4      
-    ] => integer?
-    passed
+        ; :range
+        a: to :rational [8 2]
+        
+        ensure -> 4   = clamp 4   0..4
+        ensure -> 4.0 = clamp 4.0 0..4
+        ensure -> a   = clamp a   0..4
+        ensure -> 2   = clamp 4   0..2
+        ensure -> 2.0 = clamp 4.0 0..2
+        ensure -> 2   = clamp a   0..2
+        passed
+        
+        ensure -> integer?  clamp 4   0..4
+        ensure -> floating? clamp 4.0 0..4
+        ensure -> rational? clamp a   0..4
+        ensure -> integer?  clamp 4   0..2
+        ensure -> integer?  clamp 4.0 0..2
+        ensure -> integer?  clamp a   0..2
+        passed
+        
+        ; [:integer :integer]
+        a: to :rational [8 2]
+        
+        ensure -> 4   = clamp 4   [0 4]
+        ensure -> 4.0 = clamp 4.0 [0 4]
+        ensure -> a   = clamp a   [0 4]
+        ensure -> 2   = clamp 4   [0 2]
+        ensure -> 2.0 = clamp 4.0 [0 2]
+        ensure -> 2   = clamp a   [0 2]
+        passed
+        
+        ensure -> integer?  clamp 4   [0 4]
+        ensure -> floating? clamp 4.0 [0 4]
+        ensure -> rational? clamp a   [0 4]
+        ensure -> integer?  clamp 4   [0 2]
+        ensure -> integer?  clamp 4.0 [0 2]
+        ensure -> integer?  clamp a   [0 2]
+        passed
+        
+        ; [:floating :floating]
+        a: to :rational [8 2]
+        
+        ensure -> 4   = clamp 4   [0.0 4.0]
+        ensure -> 4.0 = clamp 4.0 [0.0 4.0]
+        ensure -> a   = clamp a   [0.0 4.0]
+        ensure -> 2   = clamp 4   [0.0 2.0]
+        ensure -> 2.0 = clamp 4.0 [0.0 2.0]
+        ensure -> 2   = clamp a   [0.0 2.0]
+        passed
+        
+        ensure -> integer?  clamp 4    [0.0 4.0]
+        ensure -> floating? clamp 4.0  [0.0 4.0]
+        ensure -> rational? clamp a    [0.0 4.0]
+        ensure -> floating? clamp 4    [0.0 2.0]
+        ensure -> floating? clamp 4.0  [0.0 2.0]
+        ensure -> floating? clamp a    [0.0 2.0]
+        passed
+        
+        ; [:rational :rational]
+        a: to :rational [8 2]
+        b: to :rational [0 1]
+        c: to :rational [2 1]
+        
+        ensure -> 4   = clamp 4   @[b a]
+        ensure -> 4.0 = clamp 4.0 @[b a]
+        ensure -> a   = clamp a   @[b a]
+        ensure -> 2   = clamp 4   @[b c]
+        ensure -> 2.0 = clamp 4.0 @[b c]
+        ensure -> 2   = clamp a   @[b c]
+        passed
+        
+        ensure -> integer?  clamp 4   @[b a]
+        ensure -> floating? clamp 4.0 @[b a]
+        ensure -> rational? clamp a   @[b a]
+        ensure -> rational? clamp 4   @[b c]
+        ensure -> rational? clamp 4.0 @[b c]
+        ensure -> rational? clamp a   @[b c]
+        passed
+        
+        ; [:integer :floating]
+        a: to :rational [8 2]
+        
+        ensure -> 4   = clamp 4   [0 4.0]
+        ensure -> 4.0 = clamp 4.0 [0 4.0]
+        ensure -> a   = clamp a   [0 4.0]
+        ensure -> 2   = clamp 4   [0 2.0]
+        ensure -> 2.0 = clamp 4.0 [0 2.0]
+        ensure -> 2   = clamp a   [0 2.0]
+        passed
+        
+        ensure -> 4   = clamp 4   [0.0 4]
+        ensure -> 4.0 = clamp 4.0 [0.0 4]
+        ensure -> a   = clamp a   [0.0 4]
+        ensure -> 2   = clamp 4   [0.0 2]
+        ensure -> 2.0 = clamp 4.0 [0.0 2]
+        ensure -> 2   = clamp a   [0.0 2]
+        passed
+        
+        ensure -> integer?  clamp 4   [0 4.0]
+        ensure -> floating? clamp 4.0 [0 4.0]
+        ensure -> rational? clamp a   [0 4.0]
+        ensure -> floating? clamp 4   [0 2.0]
+        ensure -> floating? clamp 4.0 [0 2.0]
+        ensure -> floating? clamp a   [0 2.0]
+        passed
+        
+        ensure -> integer?  clamp 4   [0.0 4]
+        ensure -> floating? clamp 4.0 [0.0 4]
+        ensure -> rational? clamp a   [0.0 4]
+        ensure -> integer?  clamp 4   [0.0 2]
+        ensure -> integer?  clamp 4.0 [0.0 2]
+        ensure -> integer?  clamp a   [0.0 2]
+        passed
+        
+        ; [:integer :rational]
+        a: to :rational [8 2]
+        b: to :rational [2 1]
+        c: to :rational [0 1]
+        
+        ensure -> 4   = clamp 4   @[0 a]
+        ensure -> 4.0 = clamp 4.0 @[0 a]
+        ensure -> a   = clamp a   @[0 a]
+        ensure -> 2   = clamp 4   @[0 b]
+        ensure -> 2.0 = clamp 4.0 @[0 b]
+        ensure -> 2   = clamp a   @[0 b]
+        passed
+        
+        ensure -> 4   = clamp 4   @[c 4]
+        ensure -> 4.0 = clamp 4.0 @[c 4]
+        ensure -> a   = clamp a   @[c 4]
+        ensure -> 2   = clamp 4   @[c 2]
+        ensure -> 2.0 = clamp 4.0 @[c 2]
+        ensure -> 2   = clamp a   @[c 2]
+        passed
+        
+        ensure -> integer?  clamp 4   @[0 a]
+        ensure -> floating? clamp 4.0 @[0 a]
+        ensure -> rational? clamp a   @[0 a]
+        ensure -> rational? clamp 4   @[0 b]
+        ensure -> rational? clamp 4.0 @[0 b]
+        ensure -> rational? clamp a   @[0 b]
+        passed
+        
+        ensure -> integer?  clamp 4   @[c 4]
+        ensure -> floating? clamp 4.0 @[c 4]
+        ensure -> rational? clamp a   @[c 4]
+        ensure -> integer?  clamp 4   @[c 2]
+        ensure -> integer?  clamp 4.0 @[c 2]
+        ensure -> integer?  clamp a   @[c 2]
+        passed
+        
+        ; [:floating :rational]
+        a: to :rational [8 2]
+        b: to :rational [2 1]
+        c: to :rational [0 1]
+        
+        ensure -> 4   = clamp 4   @[0.0 a]
+        ensure -> 4.0 = clamp 4.0 @[0.0 a]
+        ensure -> a   = clamp a   @[0.0 a]
+        ensure -> 2   = clamp 4   @[0.0 b]
+        ensure -> 2.0 = clamp 4.0 @[0.0 b]
+        ensure -> 2   = clamp a   @[0.0 b]
+        passed
+        
+        ensure -> 4   = clamp 4   @[c 4.0]
+        ensure -> 4.0 = clamp 4.0 @[c 4.0]
+        ensure -> a   = clamp a   @[c 4.0]
+        ensure -> 2   = clamp 4   @[c 2.0]
+        ensure -> 2.0 = clamp 4.0 @[c 2.0]
+        ensure -> 2   = clamp a   @[c 2.0]
+        passed
+        
+        ensure -> integer?  clamp 4   @[0.0 a]
+        ensure -> floating? clamp 4.0 @[0.0 a]
+        ensure -> rational? clamp a   @[0.0 a]
+        ensure -> rational? clamp 4   @[0.0 b]
+        ensure -> rational? clamp 4.0 @[0.0 b]
+        ensure -> rational? clamp a   @[0.0 b]
+        passed
+        
+        ensure -> integer?  clamp 4   @[c 4.0]
+        ensure -> floating? clamp 4.0 @[c 4.0]
+        ensure -> rational? clamp a   @[c 4.0]
+        ensure -> floating? clamp 4   @[c 2.0]
+        ensure -> floating? clamp 4.0 @[c 2.0]
+        ensure -> floating? clamp a   @[c 2.0]
+        passed
     
+        
+    topic « clamp - returns `range`'s lower edge as :range
     
-    topic « clamp - :integer with [:integer]
-    topic « clamp - :integer with [:floating]
-    topic « clamp - :integer with [:rational]
+        ; :range
+        a: to :rational [0 1]
+        
+        ensure -> 0   = clamp 0   0..4
+        ensure -> 0.0 = clamp 0.0 0..4
+        ensure -> a   = clamp a   0..4
+        ensure -> 2   = clamp 0   2..4
+        ensure -> 2.0 = clamp 0.0 2..4
+        ensure -> 2   = clamp a   2..4
+        passed
+        
+        ensure -> integer?  clamp 0   0..4
+        ensure -> floating? clamp 0.0 0..4
+        ensure -> rational? clamp a   0..4
+        ensure -> integer?  clamp 0   2..4
+        ensure -> integer?  clamp 0.0 2..4
+        ensure -> integer?  clamp a   2..4
+        passed
+        
+        ; [:integer :integer]
+        a: to :rational [0 1]
+        
+        ensure -> 0   = clamp 0   [0 4]
+        ensure -> 0.0 = clamp 0.0 [0 4]
+        ensure -> a   = clamp a   [0 4]
+        ensure -> 2   = clamp 0   [2 4]
+        ensure -> 2.0 = clamp 0.0 [2 4]
+        ensure -> 2   = clamp a   [2 4]
+        passed
+        
+        ensure -> integer?  clamp 0   [0 4]
+        ensure -> floating? clamp 0.0 [0 4]
+        ensure -> rational? clamp a   [0 4]
+        ensure -> integer?  clamp 0   [2 4]
+        ensure -> integer?  clamp 0.0 [2 4]
+        ensure -> integer?  clamp a   [2 4]
+        passed
+        
+        ; [:floating :floating]
+        a: to :rational [0 1]
+        
+        ensure -> 0   = clamp 0   [0.0 4.0]
+        ensure -> 0.0 = clamp 0.0 [0.0 4.0]
+        ensure -> a   = clamp a   [0.0 4.0]
+        ensure -> 2   = clamp 0   [2.0 4.0]
+        ensure -> 2.0 = clamp 0.0 [2.0 4.0]
+        ensure -> 2   = clamp a   [2.0 4.0]
+        passed
+        
+        ensure -> integer?  clamp 0   [0.0 4.0]
+        ensure -> floating? clamp 0.0 [0.0 4.0]
+        ensure -> rational? clamp a   [0.0 4.0]
+        ensure -> floating? clamp 0   [2.0 4.0]
+        ensure -> floating? clamp 0.0 [2.0 4.0]
+        ensure -> floating? clamp a   [2.0 4.0]
+        passed
+        
+        ; [:rational :rational]
+        a: to :rational [0 1]
+        b: to :rational [4 1]
+        c: to :rational [2 1]
+        
+        ensure -> 0   = clamp 0   @[a b]
+        ensure -> 0.0 = clamp 0.0 @[a b]
+        ensure -> a   = clamp a   @[a b]
+        ensure -> 2   = clamp 0   @[c b]
+        ensure -> 2.0 = clamp 0.0 @[c b]
+        ensure -> 2   = clamp a   @[c b]
+        passed
+        
+        ensure -> integer?  clamp 0   @[a b]
+        ensure -> floating? clamp 0.0 @[a b]
+        ensure -> rational? clamp a   @[a b]
+        ensure -> rational? clamp 0   @[c b]
+        ensure -> rational? clamp 0.0 @[c b]
+        ensure -> rational? clamp a   @[c b]
+        passed
+        
+        ; [:integer :floating]
+        a: to :rational [0 1]
+        
+        ensure -> 0   = clamp 0   [0 4.0]
+        ensure -> 0.0 = clamp 0.0 [0 4.0]
+        ensure -> a   = clamp a   [0 4.0]
+        ensure -> 2   = clamp 0   [2 4.0]
+        ensure -> 2.0 = clamp 0.0 [2 4.0]
+        ensure -> 2   = clamp a   [2 4.0]
+        passed
+        
+        ensure -> 0   = clamp 0   [0.0 4]
+        ensure -> 0.0 = clamp 0.0 [0.0 4]
+        ensure -> a   = clamp a   [0.0 4]
+        ensure -> 2   = clamp 0   [2.0 4]
+        ensure -> 2.0 = clamp 0.0 [2.0 4]
+        ensure -> 2   = clamp a   [2.0 4]
+        passed
+        
+        ensure -> integer?  clamp 0   [0 4.0]
+        ensure -> floating? clamp 0.0 [0 4.0]
+        ensure -> rational? clamp a   [0 4.0]
+        ensure -> integer?  clamp 0   [2 4.0]
+        ensure -> integer?  clamp 0.0 [2 4.0]
+        ensure -> integer?  clamp a   [2 4.0]
+        passed
+        
+        ensure -> integer?  clamp 0   [0.0 4]
+        ensure -> floating? clamp 0.0 [0.0 4]
+        ensure -> rational? clamp a   [0.0 4]
+        ensure -> floating? clamp 0   [2.0 4]
+        ensure -> floating? clamp 0.0 [2.0 4]
+        ensure -> floating? clamp a   [2.0 4]
+        passed
+        
+        ; [:integer :rational]
+        a: to :rational [0 1]
+        b: to :rational [4 1]
+        c: to :rational [2 1]
+        
+        ensure -> 0   = clamp 0   @[0 b]
+        ensure -> 0.0 = clamp 0.0 @[0 b]
+        ensure -> a   = clamp a   @[0 b]
+        ensure -> 2   = clamp 0   @[2 b]
+        ensure -> 2.0 = clamp 0.0 @[2 b]
+        ensure -> 2   = clamp a   @[2 b]
+        passed
+        
+        ensure -> 0   = clamp 0   @[a 4]
+        ensure -> 0.0 = clamp 0.0 @[a 4]
+        ensure -> a   = clamp a   @[a 4]
+        ensure -> 2   = clamp 0   @[c 4]
+        ensure -> 2.0 = clamp 0.0 @[c 4]
+        ensure -> 2   = clamp a   @[c 4]
+        passed
+        
+        ensure -> integer?  clamp 0   @[0 b]
+        ensure -> floating? clamp 0.0 @[0 b]
+        ensure -> rational? clamp a   @[0 b]
+        ensure -> integer?  clamp 0   @[2 b]
+        ensure -> integer?  clamp 0.0 @[2 b]
+        ensure -> integer?  clamp a   @[2 b]
+        passed
+        
+        ensure -> integer?  clamp 0   @[a 4]
+        ensure -> floating? clamp 0.0 @[a 4]
+        ensure -> rational? clamp a   @[a 4]
+        ensure -> rational? clamp 0   @[b 4]
+        ensure -> rational? clamp 0.0 @[b 4]
+        ensure -> rational? clamp a   @[b 4]
+        passed
+        
+        ; [:floating :rational]
+        a: to :rational [0 1]
+        b: to :rational [4 1]
+        c: to :rational [2 1]
+        
+        ensure -> 0   = clamp 0   @[0.0 b]
+        ensure -> 0.0 = clamp 0.0 @[0.0 b]
+        ensure -> a   = clamp a   @[0.0 b]
+        ensure -> 2   = clamp 0   @[2.0 b]
+        ensure -> 2.0 = clamp 0.0 @[2.0 b]
+        ensure -> 2   = clamp a   @[2.0 b]
+        passed
+        
+        ensure -> 0   = clamp 0   @[a 4.0]
+        ensure -> 0.0 = clamp 0.0 @[a 4.0]
+        ensure -> a   = clamp a   @[a 4.0]
+        ensure -> 2   = clamp 0   @[c 4.0]
+        ensure -> 2.0 = clamp 0.0 @[c 4.0]
+        ensure -> 2   = clamp a   @[c 4.0]
+        passed
+        
+        ensure -> integer?  clamp 0   @[0.0 b]
+        ensure -> floating? clamp 0.0 @[0.0 b]
+        ensure -> rational? clamp a   @[0.0 b]
+        ensure -> floating? clamp 0   @[2.0 b]
+        ensure -> floating? clamp 0.0 @[2.0 b]
+        ensure -> floating? clamp a   @[2.0 b]
+        passed
+        
+        ensure -> integer?  clamp 0   @[a 4.0]
+        ensure -> floating? clamp 0.0 @[a 4.0]
+        ensure -> rational? clamp a   @[a 4.0]
+        ensure -> rational? clamp 0   @[b 4.0]
+        ensure -> rational? clamp 0.0 @[b 4.0]
+        ensure -> rational? clamp a   @[b 4.0]
+        passed
     
+        
+    topic « clamp - using range.step
     
-    topic « clamp - :floating with :range
+        a: to :rational [3 1]
+        b: to :rational [5 1]
     
-    ensure.that: "is within"  -> 2.5 = clamp 2.5 0..4
-    ensure.that: "is greater" -> 1   = clamp 2.5 0..1
-    ensure.that: "is less"    -> 3   = clamp 2.5 3..4
-    ensure.that: "is in the upper limit" -> 2 = clamp 2.0 0..2 
-    ensure.that: "is in the lower limit" -> 2 = clamp 2.0 2..4
+        ensure -> 3 = clamp 3 range.step: 2 5 2
+        ensure -> 3 = clamp 3.0 range.step: 2 5 2
+        ensure -> 3 = clamp a range.step: 2 5 2
+        passed
+        
+        ensure -> 4 = clamp 5 range.step: 2 2 5
+        ensure -> 4 = clamp 5.0 range.step: 2 2 5
+        ensure -> 4 = clamp b range.step: 2 2 5
+        passed
     
-    ensure.that: "works with .step attribute" -> 
-        4 = clamp 5.0 range.step: 2 0 5
-    ensure.that: "works with descending range" -> 
-        5 = clamp 5.0 range.step: 2 5 0
-    ensure.that: "works with descending and stepped range" -> 
-        3 = clamp 1.0 range.step: 2 5 2
-    passed
-    
-    
-    ensure.that: {
-        returns :integer 
-        for :floating parameter that is outside the range
-    } -> every? @[  
-        clamp 5.0 6..10    
-        clamp 5.0 0..4       
-        clamp 5.5 6..10    
-        clamp 5.5 0..4      
-    ] => integer?
-    passed
-    
-    ensure.that: {
-        returns :floating 
-        for :floating parameter that is already within the range
-    } -> every? @[
-        clamp 5.0 0..10    
-        clamp 5.5 0..10 
-    ] => floating? 
-    passed
-    
-    topic « clamp - :floating with [:integer]
-    topic « clamp - :floating with [:floating]
-    topic « clamp - :floating with [:rational]
-    
-    
-    topic « clamp - :rational with :range
-    
-    a: to :rational [5 2]
-    b: to :rational [2 1]
-    
-    ensure.that: "is within"  -> a = clamp a 0..4
-    ensure.that: "is greater" -> 1 = clamp a 0..1
-    ensure.that: "is less"    -> 3 = clamp a 3..4
-    ensure.that: "is in the upper limit" -> 2 = clamp b 0..2 
-    ensure.that: "is in the lower limit" -> 2 = clamp b 2..4
-    
-    a: to :rational [5 1]
-    b: to :rational [1 1]
-    
-    ensure.that: "works with .step attribute" -> 
-        4 = clamp a range.step: 2 0 5
-    ensure.that: "works with descending range" -> 
-        5 = clamp a range.step: 2 5 0
-    ensure.that: "works with descending and stepped range" -> 
-        3 = clamp b range.step: 2 5 2
-    passed
-    
-    a: to :rational [5 1]
-    b: to :rational [11 2]
-    
-    ensure.that: {
-        returns :integer 
-        for :rational parameter that is outside the range
-    } -> every? @[  
-        clamp a 6..10    
-        clamp a 0..4       
-        clamp b 6..10    
-        clamp b 0..4      
-    ] => integer?
-    passed
-    
-    ensure.that: {
-        returns :rational 
-        for :rational parameter that is already within the range
-    } -> every? @[
-        clamp a 0..10    
-        clamp b 0..10 
-    ] => rational? 
-    passed
-    
-    topic « clamp - :rational with [:integer]
-    topic « clamp - :rational with [:floating]
-    topic « clamp - :rational with [:rational] 
+        ensure -> integer?  clamp 3 range.step: 2   5 2
+        ensure -> floating? clamp 3.0 range.step: 2 5 2
+        ensure -> rational? clamp a range.step: 2   5 2
+        passed
+        
+        ensure -> integer? clamp 5 range.step: 2 2 5
+        ensure -> integer? clamp 5.0 range.step: 2 2 5
+        ensure -> integer? clamp b range.step: 2 2 5
+        passed
     
     
     topic « clamp - invalid operations
     
-    ensure -> every? @[
-        -> clamp 2 `a`..`d`
-        -> clamp `b` `a`..`c`
-    ] => throws? passed 
+        ensure -> every? @[
+            -> clamp 2 `a`..`d`
+            -> clamp `b` `a`..`c`
+        ] => throws? passed 
     
     
 ]

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -557,6 +557,13 @@ do [
         ensure -> every? @[
             -> clamp 2 `a`..`d`
             -> clamp `b` `a`..`c`
+            -> clamp 2 []
+            -> clamp 2 [1 1 1]
+            -> clamp 2 [a a]
+            -> clamp 2 ["a" "a"]
+            -> clamp 2 [[] []]
+            -> clamp 2 [() ()]
+            -> clamp 2 [`a` `a`]
         ] => throws? passed 
     
     

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -113,9 +113,9 @@ do [
     
     
     topic « clamp - :rational with :range
-    topic « clamp - :floating with [:integer]
-    topic « clamp - :floating with [:floating]
-    topic « clamp - :floating with [:rational] 
+    topic « clamp - :rational with [:integer]
+    topic « clamp - :rational with [:floating]
+    topic « clamp - :rational with [:rational] 
     
     
     topic « clamp - invalid operations

--- a/tests/unittests/lib.numbers.art
+++ b/tests/unittests/lib.numbers.art
@@ -3,22 +3,22 @@ passed: $[] -> print "[+] passed!"
 
 topic « ceil
 do [
-    
-    ensure.that: "works with :floating"          -> 3       = ceil 2.1                    
-    ensure.that: "works with :floating"          -> 3       = ceil 2.9                    
+
+    ensure.that: "works with :floating"          -> 3       = ceil 2.1
+    ensure.that: "works with :floating"          -> 3       = ceil 2.9
     ensure.that: "works with negative :floating" -> (neg 3) = ceil neg 3.5
     passed
-                   
+
     ensure.that: "works with :integer"          -> 4       = ceil 4
     ensure.that: "works with negative :integer" -> (neg 4) = ceil neg 4
     passed
-                        
+
     ensure.that: "works with :rational"
         -> 4 = ceil to :rational @[7 2]
-    ensure.that: "works with negative :rational" 
+    ensure.that: "works with negative :rational"
         -> (neg 3) = ceil to :rational @[neg 7 2]
     passed
-    
+
     ensure.that: "always returns :integer" -> every? @[
         ceil 2.1
         ceil 2.9
@@ -28,53 +28,53 @@ do [
         ceil neg 4
         ceil to :rational @[7 2]
         ceil to :rational @[neg 7 2]
-    ] => integer? 
+    ] => integer?
     passed
-    
+
 ]
 
 
 topic « clamp
 do [
-    
-    
+
+
     topic « clamp - returns the `number`
-    
+
         a: to :rational [4 2]
-        
+
         ; :range
         ensure -> 2   = clamp 2   0..4
         ensure -> 2.0 = clamp 2.0 0..4
         ensure -> a   = clamp a   0..4
         passed
-        
+
         ensure -> integer?  clamp 2   0..4
         ensure -> floating? clamp 2.0 0..4
         ensure -> rational? clamp a   0..4
         passed
-        
+
         ; [:integer :integer]
         ensure -> 2   = clamp 2   [0 4]
         ensure -> 2.0 = clamp 2.0 [0 4]
         ensure -> a   = clamp a   [0 4]
         passed
-        
+
         ensure -> integer?  clamp 2   [0 4]
         ensure -> floating? clamp 2.0 [0 4]
         ensure -> rational? clamp a   [0 4]
         passed
-        
+
         ; [:floating :floating]
         ensure -> 2   = clamp 2   [0.0 4.0]
         ensure -> 2.0 = clamp 2.0 [0.0 4.0]
         ensure -> a   = clamp a   [0.0 4.0]
         passed
-        
+
         ensure -> integer?  clamp 2   [0 4]
         ensure -> floating? clamp 2.0 [0 4]
         ensure -> rational? clamp a   [0 4]
         passed
-        
+
         ; [:rational :rational]
         a: to :rational [0 1]
         b: to :rational [4 1]
@@ -82,12 +82,12 @@ do [
         ensure -> 2.0 = clamp 2.0 @[a b]
         ensure -> a   = clamp a   @[a b]
         passed
-        
+
         ensure -> integer?  clamp 2   @[a b]
         ensure -> floating? clamp 2.0 @[a b]
         ensure -> rational? clamp a   @[a b]
         passed
-        
+
         ; [:integer :floating]
         a: to :rational [0 1]
         b: to :rational [4 1]
@@ -98,7 +98,7 @@ do [
         ensure -> 2.0 = clamp 2.0 @[0.0   4]
         ensure -> a   = clamp a   @[0.0   4]
         passed
-        
+
         ensure -> integer?  clamp 2   @[0   4.0]
         ensure -> floating? clamp 2.0 @[0   4.0]
         ensure -> rational? clamp a   @[0   4.0]
@@ -106,7 +106,7 @@ do [
         ensure -> floating? clamp 2.0 @[0.0   4]
         ensure -> rational? clamp a   @[0.0   4]
         passed
-        
+
         ; [:integer :rational]
         a: to :rational [4 1]
         b: to :rational [0 1]
@@ -117,7 +117,7 @@ do [
         ensure -> 2.0 = clamp 2.0 @[b 4]
         ensure -> b   = clamp b   @[b 4]
         passed
-        
+
         ensure -> integer?  clamp 2   @[0 a]
         ensure -> floating? clamp 2.0 @[0 a]
         ensure -> rational? clamp b   @[0 a]
@@ -125,7 +125,7 @@ do [
         ensure -> floating? clamp 2.0 @[b 4]
         ensure -> rational? clamp b   @[b 4]
         passed
-        
+
         ; [:floating :rational]
         a: to :rational [4 1]
         b: to :rational [0 1]
@@ -136,7 +136,7 @@ do [
         ensure -> 2.0 = clamp 2.0 @[b 4.0]
         ensure -> b   = clamp b   @[b 4.0]
         passed
-        
+
         ensure -> integer?  clamp 2   @[0.0 a]
         ensure -> floating? clamp 2.0 @[0.0 a]
         ensure -> rational? clamp b   @[0.0 a]
@@ -144,13 +144,13 @@ do [
         ensure -> floating? clamp 2.0 @[b 4.0]
         ensure -> rational? clamp b   @[b 4.0]
         passed
-    
-    
+
+
     topic « clamp - returns `range`'s upper edge
-    
+
         ; :range
         a: to :rational [8 2]
-        
+
         ensure -> 4   = clamp 4   0..4
         ensure -> 4.0 = clamp 4.0 0..4
         ensure -> a   = clamp a   0..4
@@ -158,7 +158,7 @@ do [
         ensure -> 2.0 = clamp 4.0 0..2
         ensure -> 2   = clamp a   0..2
         passed
-        
+
         ensure -> integer?  clamp 4   0..4
         ensure -> floating? clamp 4.0 0..4
         ensure -> rational? clamp a   0..4
@@ -166,10 +166,10 @@ do [
         ensure -> integer?  clamp 4.0 0..2
         ensure -> integer?  clamp a   0..2
         passed
-        
+
         ; [:integer :integer]
         a: to :rational [8 2]
-        
+
         ensure -> 4   = clamp 4   [0 4]
         ensure -> 4.0 = clamp 4.0 [0 4]
         ensure -> a   = clamp a   [0 4]
@@ -177,7 +177,7 @@ do [
         ensure -> 2.0 = clamp 4.0 [0 2]
         ensure -> 2   = clamp a   [0 2]
         passed
-        
+
         ensure -> integer?  clamp 4   [0 4]
         ensure -> floating? clamp 4.0 [0 4]
         ensure -> rational? clamp a   [0 4]
@@ -185,10 +185,10 @@ do [
         ensure -> integer?  clamp 4.0 [0 2]
         ensure -> integer?  clamp a   [0 2]
         passed
-        
+
         ; [:floating :floating]
         a: to :rational [8 2]
-        
+
         ensure -> 4   = clamp 4   [0.0 4.0]
         ensure -> 4.0 = clamp 4.0 [0.0 4.0]
         ensure -> a   = clamp a   [0.0 4.0]
@@ -196,7 +196,7 @@ do [
         ensure -> 2.0 = clamp 4.0 [0.0 2.0]
         ensure -> 2   = clamp a   [0.0 2.0]
         passed
-        
+
         ensure -> integer?  clamp 4    [0.0 4.0]
         ensure -> floating? clamp 4.0  [0.0 4.0]
         ensure -> rational? clamp a    [0.0 4.0]
@@ -204,12 +204,12 @@ do [
         ensure -> floating? clamp 4.0  [0.0 2.0]
         ensure -> floating? clamp a    [0.0 2.0]
         passed
-        
+
         ; [:rational :rational]
         a: to :rational [8 2]
         b: to :rational [0 1]
         c: to :rational [2 1]
-        
+
         ensure -> 4   = clamp 4   @[b a]
         ensure -> 4.0 = clamp 4.0 @[b a]
         ensure -> a   = clamp a   @[b a]
@@ -217,7 +217,7 @@ do [
         ensure -> 2.0 = clamp 4.0 @[b c]
         ensure -> 2   = clamp a   @[b c]
         passed
-        
+
         ensure -> integer?  clamp 4   @[b a]
         ensure -> floating? clamp 4.0 @[b a]
         ensure -> rational? clamp a   @[b a]
@@ -225,10 +225,10 @@ do [
         ensure -> rational? clamp 4.0 @[b c]
         ensure -> rational? clamp a   @[b c]
         passed
-        
+
         ; [:integer :floating]
         a: to :rational [8 2]
-        
+
         ensure -> 4   = clamp 4   [0 4.0]
         ensure -> 4.0 = clamp 4.0 [0 4.0]
         ensure -> a   = clamp a   [0 4.0]
@@ -236,7 +236,7 @@ do [
         ensure -> 2.0 = clamp 4.0 [0 2.0]
         ensure -> 2   = clamp a   [0 2.0]
         passed
-        
+
         ensure -> 4   = clamp 4   [0.0 4]
         ensure -> 4.0 = clamp 4.0 [0.0 4]
         ensure -> a   = clamp a   [0.0 4]
@@ -244,7 +244,7 @@ do [
         ensure -> 2.0 = clamp 4.0 [0.0 2]
         ensure -> 2   = clamp a   [0.0 2]
         passed
-        
+
         ensure -> integer?  clamp 4   [0 4.0]
         ensure -> floating? clamp 4.0 [0 4.0]
         ensure -> rational? clamp a   [0 4.0]
@@ -252,7 +252,7 @@ do [
         ensure -> floating? clamp 4.0 [0 2.0]
         ensure -> floating? clamp a   [0 2.0]
         passed
-        
+
         ensure -> integer?  clamp 4   [0.0 4]
         ensure -> floating? clamp 4.0 [0.0 4]
         ensure -> rational? clamp a   [0.0 4]
@@ -260,12 +260,12 @@ do [
         ensure -> integer?  clamp 4.0 [0.0 2]
         ensure -> integer?  clamp a   [0.0 2]
         passed
-        
+
         ; [:integer :rational]
         a: to :rational [8 2]
         b: to :rational [2 1]
         c: to :rational [0 1]
-        
+
         ensure -> 4   = clamp 4   @[0 a]
         ensure -> 4.0 = clamp 4.0 @[0 a]
         ensure -> a   = clamp a   @[0 a]
@@ -273,7 +273,7 @@ do [
         ensure -> 2.0 = clamp 4.0 @[0 b]
         ensure -> 2   = clamp a   @[0 b]
         passed
-        
+
         ensure -> 4   = clamp 4   @[c 4]
         ensure -> 4.0 = clamp 4.0 @[c 4]
         ensure -> a   = clamp a   @[c 4]
@@ -281,7 +281,7 @@ do [
         ensure -> 2.0 = clamp 4.0 @[c 2]
         ensure -> 2   = clamp a   @[c 2]
         passed
-        
+
         ensure -> integer?  clamp 4   @[0 a]
         ensure -> floating? clamp 4.0 @[0 a]
         ensure -> rational? clamp a   @[0 a]
@@ -289,7 +289,7 @@ do [
         ensure -> rational? clamp 4.0 @[0 b]
         ensure -> rational? clamp a   @[0 b]
         passed
-        
+
         ensure -> integer?  clamp 4   @[c 4]
         ensure -> floating? clamp 4.0 @[c 4]
         ensure -> rational? clamp a   @[c 4]
@@ -297,12 +297,12 @@ do [
         ensure -> integer?  clamp 4.0 @[c 2]
         ensure -> integer?  clamp a   @[c 2]
         passed
-        
+
         ; [:floating :rational]
         a: to :rational [8 2]
         b: to :rational [2 1]
         c: to :rational [0 1]
-        
+
         ensure -> 4   = clamp 4   @[0.0 a]
         ensure -> 4.0 = clamp 4.0 @[0.0 a]
         ensure -> a   = clamp a   @[0.0 a]
@@ -310,7 +310,7 @@ do [
         ensure -> 2.0 = clamp 4.0 @[0.0 b]
         ensure -> 2   = clamp a   @[0.0 b]
         passed
-        
+
         ensure -> 4   = clamp 4   @[c 4.0]
         ensure -> 4.0 = clamp 4.0 @[c 4.0]
         ensure -> a   = clamp a   @[c 4.0]
@@ -318,7 +318,7 @@ do [
         ensure -> 2.0 = clamp 4.0 @[c 2.0]
         ensure -> 2   = clamp a   @[c 2.0]
         passed
-        
+
         ensure -> integer?  clamp 4   @[0.0 a]
         ensure -> floating? clamp 4.0 @[0.0 a]
         ensure -> rational? clamp a   @[0.0 a]
@@ -326,7 +326,7 @@ do [
         ensure -> rational? clamp 4.0 @[0.0 b]
         ensure -> rational? clamp a   @[0.0 b]
         passed
-        
+
         ensure -> integer?  clamp 4   @[c 4.0]
         ensure -> floating? clamp 4.0 @[c 4.0]
         ensure -> rational? clamp a   @[c 4.0]
@@ -334,13 +334,13 @@ do [
         ensure -> floating? clamp 4.0 @[c 2.0]
         ensure -> floating? clamp a   @[c 2.0]
         passed
-    
-        
+
+
     topic « clamp - returns `range`'s lower edge as :range
-    
+
         ; :range
         a: to :rational [0 1]
-        
+
         ensure -> 0   = clamp 0   0..4
         ensure -> 0.0 = clamp 0.0 0..4
         ensure -> a   = clamp a   0..4
@@ -348,7 +348,7 @@ do [
         ensure -> 2.0 = clamp 0.0 2..4
         ensure -> 2   = clamp a   2..4
         passed
-        
+
         ensure -> integer?  clamp 0   0..4
         ensure -> floating? clamp 0.0 0..4
         ensure -> rational? clamp a   0..4
@@ -356,10 +356,10 @@ do [
         ensure -> integer?  clamp 0.0 2..4
         ensure -> integer?  clamp a   2..4
         passed
-        
+
         ; [:integer :integer]
         a: to :rational [0 1]
-        
+
         ensure -> 0   = clamp 0   [0 4]
         ensure -> 0.0 = clamp 0.0 [0 4]
         ensure -> a   = clamp a   [0 4]
@@ -367,7 +367,7 @@ do [
         ensure -> 2.0 = clamp 0.0 [2 4]
         ensure -> 2   = clamp a   [2 4]
         passed
-        
+
         ensure -> integer?  clamp 0   [0 4]
         ensure -> floating? clamp 0.0 [0 4]
         ensure -> rational? clamp a   [0 4]
@@ -375,10 +375,10 @@ do [
         ensure -> integer?  clamp 0.0 [2 4]
         ensure -> integer?  clamp a   [2 4]
         passed
-        
+
         ; [:floating :floating]
         a: to :rational [0 1]
-        
+
         ensure -> 0   = clamp 0   [0.0 4.0]
         ensure -> 0.0 = clamp 0.0 [0.0 4.0]
         ensure -> a   = clamp a   [0.0 4.0]
@@ -386,7 +386,7 @@ do [
         ensure -> 2.0 = clamp 0.0 [2.0 4.0]
         ensure -> 2   = clamp a   [2.0 4.0]
         passed
-        
+
         ensure -> integer?  clamp 0   [0.0 4.0]
         ensure -> floating? clamp 0.0 [0.0 4.0]
         ensure -> rational? clamp a   [0.0 4.0]
@@ -394,12 +394,12 @@ do [
         ensure -> floating? clamp 0.0 [2.0 4.0]
         ensure -> floating? clamp a   [2.0 4.0]
         passed
-        
+
         ; [:rational :rational]
         a: to :rational [0 1]
         b: to :rational [4 1]
         c: to :rational [2 1]
-        
+
         ensure -> 0   = clamp 0   @[a b]
         ensure -> 0.0 = clamp 0.0 @[a b]
         ensure -> a   = clamp a   @[a b]
@@ -407,7 +407,7 @@ do [
         ensure -> 2.0 = clamp 0.0 @[c b]
         ensure -> 2   = clamp a   @[c b]
         passed
-        
+
         ensure -> integer?  clamp 0   @[a b]
         ensure -> floating? clamp 0.0 @[a b]
         ensure -> rational? clamp a   @[a b]
@@ -415,10 +415,10 @@ do [
         ensure -> rational? clamp 0.0 @[c b]
         ensure -> rational? clamp a   @[c b]
         passed
-        
+
         ; [:integer :floating]
         a: to :rational [0 1]
-        
+
         ensure -> 0   = clamp 0   [0 4.0]
         ensure -> 0.0 = clamp 0.0 [0 4.0]
         ensure -> a   = clamp a   [0 4.0]
@@ -426,7 +426,7 @@ do [
         ensure -> 2.0 = clamp 0.0 [2 4.0]
         ensure -> 2   = clamp a   [2 4.0]
         passed
-        
+
         ensure -> 0   = clamp 0   [0.0 4]
         ensure -> 0.0 = clamp 0.0 [0.0 4]
         ensure -> a   = clamp a   [0.0 4]
@@ -434,7 +434,7 @@ do [
         ensure -> 2.0 = clamp 0.0 [2.0 4]
         ensure -> 2   = clamp a   [2.0 4]
         passed
-        
+
         ensure -> integer?  clamp 0   [0 4.0]
         ensure -> floating? clamp 0.0 [0 4.0]
         ensure -> rational? clamp a   [0 4.0]
@@ -442,7 +442,7 @@ do [
         ensure -> integer?  clamp 0.0 [2 4.0]
         ensure -> integer?  clamp a   [2 4.0]
         passed
-        
+
         ensure -> integer?  clamp 0   [0.0 4]
         ensure -> floating? clamp 0.0 [0.0 4]
         ensure -> rational? clamp a   [0.0 4]
@@ -450,12 +450,12 @@ do [
         ensure -> floating? clamp 0.0 [2.0 4]
         ensure -> floating? clamp a   [2.0 4]
         passed
-        
+
         ; [:integer :rational]
         a: to :rational [0 1]
         b: to :rational [4 1]
         c: to :rational [2 1]
-        
+
         ensure -> 0   = clamp 0   @[0 b]
         ensure -> 0.0 = clamp 0.0 @[0 b]
         ensure -> a   = clamp a   @[0 b]
@@ -463,7 +463,7 @@ do [
         ensure -> 2.0 = clamp 0.0 @[2 b]
         ensure -> 2   = clamp a   @[2 b]
         passed
-        
+
         ensure -> 0   = clamp 0   @[a 4]
         ensure -> 0.0 = clamp 0.0 @[a 4]
         ensure -> a   = clamp a   @[a 4]
@@ -471,7 +471,7 @@ do [
         ensure -> 2.0 = clamp 0.0 @[c 4]
         ensure -> 2   = clamp a   @[c 4]
         passed
-        
+
         ensure -> integer?  clamp 0   @[0 b]
         ensure -> floating? clamp 0.0 @[0 b]
         ensure -> rational? clamp a   @[0 b]
@@ -479,7 +479,7 @@ do [
         ensure -> integer?  clamp 0.0 @[2 b]
         ensure -> integer?  clamp a   @[2 b]
         passed
-        
+
         ensure -> integer?  clamp 0   @[a 4]
         ensure -> floating? clamp 0.0 @[a 4]
         ensure -> rational? clamp a   @[a 4]
@@ -487,12 +487,12 @@ do [
         ensure -> rational? clamp 0.0 @[b 4]
         ensure -> rational? clamp a   @[b 4]
         passed
-        
+
         ; [:floating :rational]
         a: to :rational [0 1]
         b: to :rational [4 1]
         c: to :rational [2 1]
-        
+
         ensure -> 0   = clamp 0   @[0.0 b]
         ensure -> 0.0 = clamp 0.0 @[0.0 b]
         ensure -> a   = clamp a   @[0.0 b]
@@ -500,7 +500,7 @@ do [
         ensure -> 2.0 = clamp 0.0 @[2.0 b]
         ensure -> 2   = clamp a   @[2.0 b]
         passed
-        
+
         ensure -> 0   = clamp 0   @[a 4.0]
         ensure -> 0.0 = clamp 0.0 @[a 4.0]
         ensure -> a   = clamp a   @[a 4.0]
@@ -508,7 +508,7 @@ do [
         ensure -> 2.0 = clamp 0.0 @[c 4.0]
         ensure -> 2   = clamp a   @[c 4.0]
         passed
-        
+
         ensure -> integer?  clamp 0   @[0.0 b]
         ensure -> floating? clamp 0.0 @[0.0 b]
         ensure -> rational? clamp a   @[0.0 b]
@@ -516,7 +516,7 @@ do [
         ensure -> floating? clamp 0.0 @[2.0 b]
         ensure -> floating? clamp a   @[2.0 b]
         passed
-        
+
         ensure -> integer?  clamp 0   @[a 4.0]
         ensure -> floating? clamp 0.0 @[a 4.0]
         ensure -> rational? clamp a   @[a 4.0]
@@ -524,36 +524,36 @@ do [
         ensure -> rational? clamp 0.0 @[b 4.0]
         ensure -> rational? clamp a   @[b 4.0]
         passed
-    
-        
+
+
     topic « clamp - using range.step
-    
+
         a: to :rational [3 1]
         b: to :rational [5 1]
-    
+
         ensure -> 3 = clamp 3 range.step: 2 5 2
         ensure -> 3 = clamp 3.0 range.step: 2 5 2
         ensure -> 3 = clamp a range.step: 2 5 2
         passed
-        
+
         ensure -> 4 = clamp 5 range.step: 2 2 5
         ensure -> 4 = clamp 5.0 range.step: 2 2 5
         ensure -> 4 = clamp b range.step: 2 2 5
         passed
-    
+
         ensure -> integer?  clamp 3 range.step: 2   5 2
         ensure -> floating? clamp 3.0 range.step: 2 5 2
         ensure -> rational? clamp a range.step: 2   5 2
         passed
-        
+
         ensure -> integer? clamp 5 range.step: 2 2 5
         ensure -> integer? clamp 5.0 range.step: 2 2 5
         ensure -> integer? clamp b range.step: 2 2 5
         passed
-    
-    
+
+
     topic « clamp - invalid operations
-    
+
         ensure -> every? @[
             -> clamp 2 `a`..`d`
             -> clamp `b` `a`..`c`
@@ -564,29 +564,29 @@ do [
             -> clamp 2 [[] []]
             -> clamp 2 [() ()]
             -> clamp 2 [`a` `a`]
-        ] => throws? passed 
-    
-    
+        ] => throws? passed
+
+
 ]
 
 topic « floor
 do [
-    
-    ensure.that: "works with :floating"          -> 2       = floor 2.1                    
-    ensure.that: "works with :floating"          -> 2       = floor 2.9                    
+
+    ensure.that: "works with :floating"          -> 2       = floor 2.1
+    ensure.that: "works with :floating"          -> 2       = floor 2.9
     ensure.that: "works with negative :floating" -> (neg 4) = floor neg 3.5
     passed
-                   
+
     ensure.that: "works with :integer"          -> 4       = floor 4
     ensure.that: "works with negative :integer" -> (neg 4) = floor neg 4
     passed
-                        
+
     ensure.that: "works with :rational"
         -> 3 = floor to :rational @[7 2]
-    ensure.that: "works with negative :rational" 
+    ensure.that: "works with negative :rational"
         -> (neg 4) = floor to :rational @[neg 7 2]
     passed
-    
+
     ensure.that: "always returns :integer" -> every? @[
         floor 2.1
         floor 2.9
@@ -596,20 +596,20 @@ do [
         floor neg 4
         floor to :rational @[7 2]
         floor to :rational @[neg 7 2]
-    ] => integer? 
+    ] => integer?
     passed
-    
+
 ]
 
 
 topic « round
 do [
-    
-    ensure.that: "works with :floating"          -> 2.0       = round 2.1                    
-    ensure.that: "works with :floating"          -> 3.0       = round 2.9                    
+
+    ensure.that: "works with :floating"          -> 2.0       = round 2.1
+    ensure.that: "works with :floating"          -> 3.0       = round 2.9
     ensure.that: "works with negative :floating" -> (neg 4.0) = round neg 3.5
     passed
-                   
+
     ensure.that: "works with :integer"          -> 4       = round 4
     ensure.that: "works with negative :integer" -> (neg 4) = round neg 4
     passed
@@ -621,7 +621,7 @@ do [
     ensure.that: "works with :rational" -> (neg 3) = round to :rational @[neg 29 10]
     ensure.that: "works with :rational" -> (neg 2) = round to :rational @[neg 21 10]
     passed
-    
+
     ensure.that: "always returns :floating" -> every? @[
         round 2.1
         round 2.9
@@ -635,7 +635,7 @@ do [
         round to :rational @[neg 29 10]
         round to :rational @[21 10]
         round to :rational @[neg 21 10]
-    ] => floating? 
+    ] => floating?
     passed
-    
+
 ]

--- a/tests/unittests/lib.numbers.res
+++ b/tests/unittests/lib.numbers.res
@@ -29,12 +29,15 @@
 >> clamp - :floating with [:rational]
 
 >> clamp - :rational with :range
+[+] passed!
+[+] passed!
+[+] passed!
 
->> clamp - :floating with [:integer]
+>> clamp - :rational with [:integer]
 
->> clamp - :floating with [:floating]
+>> clamp - :rational with [:floating]
 
->> clamp - :floating with [:rational]
+>> clamp - :rational with [:rational]
 
 >> clamp - invalid operations
 [+] passed!

--- a/tests/unittests/lib.numbers.res
+++ b/tests/unittests/lib.numbers.res
@@ -7,37 +7,71 @@
 
 >> clamp
 
->> clamp - :integer with :range
-[+] passed!
-[+] passed!
-
->> clamp - :integer with [:integer]
-
->> clamp - :integer with [:floating]
-
->> clamp - :integer with [:rational]
-
->> clamp - :floating with :range
+>> clamp - returns the `number`
 [+] passed!
 [+] passed!
 [+] passed!
-
->> clamp - :floating with [:integer]
-
->> clamp - :floating with [:floating]
-
->> clamp - :floating with [:rational]
-
->> clamp - :rational with :range
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
 [+] passed!
 [+] passed!
 [+] passed!
 
->> clamp - :rational with [:integer]
+>> clamp - returns `range`'s upper edge
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
 
->> clamp - :rational with [:floating]
+>> clamp - returns `range`'s lower edge as :range
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
 
->> clamp - :rational with [:rational]
+>> clamp - using range.step
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
 
 >> clamp - invalid operations
 [+] passed!

--- a/tests/unittests/lib.numbers.res
+++ b/tests/unittests/lib.numbers.res
@@ -6,17 +6,37 @@
 [+] passed!
 
 >> clamp
+
+>> clamp - :integer with :range
+[+] passed!
+[+] passed!
+
+>> clamp - :integer with [:integer]
+
+>> clamp - :integer with [:floating]
+
+>> clamp - :integer with [:rational]
+
+>> clamp - :floating with :range
 [+] passed!
 [+] passed!
 [+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
-[+] passed!
+
+>> clamp - :floating with [:integer]
+
+>> clamp - :floating with [:floating]
+
+>> clamp - :floating with [:rational]
+
+>> clamp - :rational with :range
+
+>> clamp - :floating with [:integer]
+
+>> clamp - :floating with [:floating]
+
+>> clamp - :floating with [:rational]
+
+>> clamp - invalid operations
 [+] passed!
 
 >> floor


### PR DESCRIPTION
# Description

Enhance `clamp` adding support to more types

## Tasks

- [x] Add support to `number :rational`
- [x] Add support to `range [:integer]`
- [x] Add support to `range [:floating]`
- [x] Add support to `range [:rational]`
- [x] Ensure that works for descending `range :block` too

## Related
> clamp is actually based on Value comparisons and since Value comparisons are already in place (in the PR) for Rational values, this should just require updating the function signature (add support for Rational, apart from Integers and Floating-point numbers).
> 
> P.S. I'm not sure it'll work extremely well right now, but once the PR is merged, it will. But we could definitely do this^ part now... (@ name: « Takemichi if you have time, you can certainly go on 😉 ; if not, I'll do it myself! 🙂 )

[this message from @drkameleon][discord]

## Type of change

- [x] Code cleanup
- [x] New feature (non-breaking change which adds functionality)
- [x] Add/Update unit-tests
- [x] This change requires a documentation update

[discord]: https://discord.com/channels/765519132186640445/829324913097048065/1105770438111539200