### PR TITLE
[Collections\drop & take] fix SIGSEGV errors

### DIFF
--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -380,11 +380,16 @@ proc defineSymbols*() =
         attrs       = NoAttrs,
         returns     = {String, Block, Nothing},
         example     = """
-            str: drop "some text" 5
-            print str                     ; text
+            str: "some text"
+            drop str 5                  ; => text
+            drop str neg 5              ; => some
             ..........
-            arr: 1..10
-            drop 'arr 3                   ; arr: [4 5 6 7 8 9 10]
+            arr: @1..10
+            drop 'arr 3                   
+            arr                         ; => [4 5 6 7 8 9 10]
+            ..........
+            drop [1 2 3] 3              ; => []
+            drop [1 2 3] 4              ; => []
         """:
             #=======================================================
             

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2281,8 +2281,14 @@ proc defineSymbols*() =
             #=======================================================
             
             template getUpperLimit(container: (ValueArray|string)): int =
-                if y.i > container.len: container.len - 1
-                else: y.i - 1
+                if abs(y.i) > container.len: container.len - 1
+                else: abs(y.i) - 1
+            
+            template take(container :untyped, upperLimit: int): untyped =
+                if 0 < y.i:
+                    container[0..upperLimit]
+                else:
+                    container[container.high - upperLimit..^1]
             
             if x.kind == Literal:
                 ensureInPlace()
@@ -2290,11 +2296,11 @@ proc defineSymbols*() =
                 of String:
                     if x.s.len > 0:
                         let upperLimit: int = InPlaced.s.getUpperLimit()
-                        InPlaced.s = InPlaced.s[0..upperLimit]
+                        InPlaced.s = InPlaced.s.take(upperLimit)
                 of Block:
                     if InPlaced.a.len > 0:
                         let upperLimit: int = InPlaced.a.getUpperLimit()
-                        InPlaced.a = InPlaced.a[0..upperLimit]
+                        InPlaced.a = InPlaced.a.take(upperLimit)
                 of Range:
                     let size = if y.i < InPlaced.rng.len: y.i 
                                else: InPlaced.rng.len
@@ -2312,12 +2318,12 @@ proc defineSymbols*() =
                     if x.s.len == 0: push(newString(""))
                     else:
                         let upperLimit: int = x.s.getUpperLimit()
-                        push(newString(x.s[0..upperLimit]))
+                        push(newString(x.s.take(upperLimit)))
                 of Block:
                     if x.a.len == 0: push(newBlock())
                     else:
                         let upperLimit: int = x.a.getUpperLimit()
-                        push(newBlock(x.a[0..upperLimit]))
+                        push(newBlock(x.a.take(upperLimit)))
                 of Range:
                     let size = if y.i < x.rng.len: y.i 
                                else: x.rng.len

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2258,8 +2258,6 @@ proc defineSymbols*() =
                         i += 1
                     push(newBlock(ret))
 
-    # TODO(Collections\take) returns SIGSEGV in some cases
-    #  - when y param is negative
     builtin "take",
         alias       = unaliased,
         op          = opNop,

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2248,6 +2248,7 @@ proc defineSymbols*() =
     # TODO(Collections\take) returns SIGSEGV in some cases
     #  - when y param is 0
     #  - when y param is greater than a :range x param
+    #  - when y param is negative
     builtin "take",
         alias       = unaliased,
         op          = opNop,
@@ -2281,12 +2282,14 @@ proc defineSymbols*() =
                             upperLimit = InPlaced.a.len-1
                         InPlaced.a = InPlaced.a[0..upperLimit]
                 elif InPlaced.kind == Range:
-                    var res: ValueArray = newSeq[Value](upperLimit+1)
+                    let size = if y.i < InPlaced.rng.len: y.i 
+                               else: InPlaced.rng.len
+                    var res: ValueArray = newSeq[Value](size)
                     var i = 0
                     for item in items(InPlaced.rng):
+                        if i == size: break
                         res[i] = item
                         i += 1
-                        if i == upperLimit+1: break
                     InPlaced = newBlock(res)
             else:
                 if xKind == String:
@@ -2302,12 +2305,14 @@ proc defineSymbols*() =
                             upperLimit = x.a.len-1
                         push(newBlock(x.a[0..upperLimit]))
                 elif xKind == Range:
-                    var res: ValueArray = newSeq[Value](upperLimit+1)
+                    let size = if y.i < x.rng.len: y.i 
+                               else: x.rng.len
+                    var res: ValueArray = newSeq[Value](size)
                     var i = 0
                     for item in items(x.rng):
+                        if i == size: break
                         res[i] = item
                         i += 1
-                        if i == upperLimit+1: break
                     push(newBlock(res))
 
     builtin "tally",

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2272,11 +2272,18 @@ proc defineSymbols*() =
         attrs       = NoAttrs,
         returns     = {String, Block, Nothing},
         example     = """
-            str: take "some text" 5
-            print str                     ; some
+            str: "some text"
+            take str 4              ; => some
+            take str neg 4          ; => text
+            
+            take 1..3 2             ; => [1 2]
             ..........
-            arr: 1..10
-            take 'arr 3                   ; arr: [1 2 3]
+            arr: @1..10
+            take 'arr 3                   
+            arr                     ; => arr: [1 2 3]
+            ..........
+            take [1 2 3] 3          ; => [1 2 3]
+            take [1 2 3] 4          ; => [1 2 3]
         """:
             #=======================================================
             

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -364,6 +364,9 @@ proc defineSymbols*() =
             else:
                 let res = unzip(x.a.map((z)=>(requireValue(z,{Block,Inline});(z.a[0], z.a[1]))))
                 push(newBlock(@[newBlock(res[0]), newBlock(res[1])]))
+                
+                
+    # TODO(Collections\drop) returns SIGSEGV when y is a negative number 
 
     builtin "drop",
         alias       = unaliased,

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -389,29 +389,35 @@ proc defineSymbols*() =
             #=======================================================
             
             template numberInRange(container: untyped): untyped = 
-                container.len >= y.i
+                container.len >= abs(y.i)
+                
+            template drop(container: untyped): untyped =
+                if 0 < y.i:
+                    container[y.i..^1]
+                else:
+                    container[0.. container.high - abs(y.i)]
                 
             if x.kind == Literal:
                 ensureInPlace()
                 case InPlaced.kind
                 of String:
                     if numberInRange(InPlaced.s):
-                        InPlaced.s = InPlaced.s[y.i..^1]
+                        InPlaced.s = InPlaced.s.drop()
                     else: 
                         InPlaced.s = ""
                 of Block:
                     if numberInRange(InPlaced.a):
-                        InPlaced.a = InPlaced.a[y.i..^1]
+                        InPlaced.a = InPlaced.a.drop()
                     else:
                         InPlaced.a = newSeq[Value](0)
                 else: discard
             else:
                 case x.kind
                 of String:
-                    if numberInRange(x.s): push(newString(x.s[y.i..^1]))
+                    if numberInRange(x.s): push(newString(x.s.drop()))
                     else: push(newString(""))
                 of Block:
-                    if numberInRange(x.a): push(newBlock(x.a[y.i..^1]))
+                    if numberInRange(x.a): push(newBlock(x.a.drop()))
                     else: push(newBlock())
                 else: discard
 

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -387,16 +387,26 @@ proc defineSymbols*() =
             if xKind == Literal:
                 ensureInPlace()
                 if InPlaced.kind == String:
-                    InPlaced.s = InPlaced.s[y.i..^1]
+                    if InPlaced.s.len >= y.i:
+                        InPlaced.s = InPlaced.s[y.i..^1]
+                    else: 
+                        InPlaced.s = ""
                 elif InPlaced.kind == Block:
-                    if InPlaced.a.len > 0:
+                    if InPlaced.a.len >= y.i:
                         InPlaced.a = InPlaced.a[y.i..^1]
+                    else:
+                        InPlaced.a = newSeq[Value](0)
             else:
                 if xKind == String:
-                    push(newString(x.s[y.i..^1]))
+                    if x.s.len >= y.i:
+                        push(newString(x.s[y.i..^1]))
+                    else:
+                        push(newString(""))
                 elif xKind == Block:
-                    if x.a.len == 0: push(newBlock())
-                    else: push(newBlock(x.a[y.i..^1]))
+                    if x.a.len >= y.i: 
+                        push(newBlock(x.a[y.i..^1]))
+                    else: 
+                        push(newBlock())
 
     builtin "empty",
         alias       = unaliased,

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -387,29 +387,33 @@ proc defineSymbols*() =
             drop 'arr 3                   ; arr: [4 5 6 7 8 9 10]
         """:
             #=======================================================
-            if xKind == Literal:
+            
+            template numberInRange(container: untyped): untyped = 
+                container.len >= y.i
+                
+            if x.kind == Literal:
                 ensureInPlace()
-                if InPlaced.kind == String:
-                    if InPlaced.s.len >= y.i:
+                case InPlaced.kind
+                of String:
+                    if numberInRange(InPlaced.s):
                         InPlaced.s = InPlaced.s[y.i..^1]
                     else: 
                         InPlaced.s = ""
-                elif InPlaced.kind == Block:
-                    if InPlaced.a.len >= y.i:
+                of Block:
+                    if numberInRange(InPlaced.a):
                         InPlaced.a = InPlaced.a[y.i..^1]
                     else:
                         InPlaced.a = newSeq[Value](0)
+                else: discard
             else:
-                if xKind == String:
-                    if x.s.len >= y.i:
-                        push(newString(x.s[y.i..^1]))
-                    else:
-                        push(newString(""))
-                elif xKind == Block:
-                    if x.a.len >= y.i: 
-                        push(newBlock(x.a[y.i..^1]))
-                    else: 
-                        push(newBlock())
+                case x.kind
+                of String:
+                    if numberInRange(x.s): push(newString(x.s[y.i..^1]))
+                    else: push(newString(""))
+                of Block:
+                    if numberInRange(x.a): push(newBlock(x.a[y.i..^1]))
+                    else: push(newBlock())
+                else: discard
 
     builtin "empty",
         alias       = unaliased,

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2269,19 +2269,20 @@ proc defineSymbols*() =
         """:
             #=======================================================
             var upperLimit = y.i-1
-            if xKind == Literal:
+            if x.kind == Literal:
                 ensureInPlace()
-                if InPlaced.kind == String:
+                case InPlaced.kind
+                of String:
                     if x.s.len > 0:
                         if upperLimit > InPlaced.s.len - 1:
                             upperLimit = InPlaced.s.len-1
                         InPlaced.s = InPlaced.s[0..upperLimit]
-                elif InPlaced.kind == Block:
+                of Block:
                     if InPlaced.a.len > 0:
                         if upperLimit > InPlaced.a.len - 1:
                             upperLimit = InPlaced.a.len-1
                         InPlaced.a = InPlaced.a[0..upperLimit]
-                elif InPlaced.kind == Range:
+                of Range:
                     let size = if y.i < InPlaced.rng.len: y.i 
                                else: InPlaced.rng.len
                     var res: ValueArray = newSeq[Value](size)
@@ -2291,20 +2292,22 @@ proc defineSymbols*() =
                         res[i] = item
                         i += 1
                     InPlaced = newBlock(res)
+                else: discard
             else:
-                if xKind == String:
+                case x.kind
+                of String:
                     if x.s.len == 0: push(newString(""))
                     else:
                         if upperLimit > x.s.len - 1:
                             upperLimit = x.s.len-1
                         push(newString(x.s[0..upperLimit]))
-                elif xKind == Block:
+                of Block:
                     if x.a.len == 0: push(newBlock())
                     else:
                         if upperLimit > x.a.len - 1:
                             upperLimit = x.a.len-1
                         push(newBlock(x.a[0..upperLimit]))
-                elif xKind == Range:
+                of Range:
                     let size = if y.i < x.rng.len: y.i 
                                else: x.rng.len
                     var res: ValueArray = newSeq[Value](size)
@@ -2314,6 +2317,7 @@ proc defineSymbols*() =
                         res[i] = item
                         i += 1
                     push(newBlock(res))
+                else: discard
 
     builtin "tally",
         alias       = unaliased,

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2268,19 +2268,21 @@ proc defineSymbols*() =
             take 'arr 3                   ; arr: [1 2 3]
         """:
             #=======================================================
-            var upperLimit = y.i-1
+            
+            template getUpperLimit(container: (ValueArray|string)): int =
+                if y.i > container.len: container.len - 1
+                else: y.i - 1
+            
             if x.kind == Literal:
                 ensureInPlace()
                 case InPlaced.kind
                 of String:
                     if x.s.len > 0:
-                        if upperLimit > InPlaced.s.len - 1:
-                            upperLimit = InPlaced.s.len-1
+                        let upperLimit: int = InPlaced.s.getUpperLimit()
                         InPlaced.s = InPlaced.s[0..upperLimit]
                 of Block:
                     if InPlaced.a.len > 0:
-                        if upperLimit > InPlaced.a.len - 1:
-                            upperLimit = InPlaced.a.len-1
+                        let upperLimit: int = InPlaced.a.getUpperLimit()
                         InPlaced.a = InPlaced.a[0..upperLimit]
                 of Range:
                     let size = if y.i < InPlaced.rng.len: y.i 
@@ -2298,14 +2300,12 @@ proc defineSymbols*() =
                 of String:
                     if x.s.len == 0: push(newString(""))
                     else:
-                        if upperLimit > x.s.len - 1:
-                            upperLimit = x.s.len-1
+                        let upperLimit: int = x.s.getUpperLimit()
                         push(newString(x.s[0..upperLimit]))
                 of Block:
                     if x.a.len == 0: push(newBlock())
                     else:
-                        if upperLimit > x.a.len - 1:
-                            upperLimit = x.a.len-1
+                        let upperLimit: int = x.a.getUpperLimit()
                         push(newBlock(x.a[0..upperLimit]))
                 of Range:
                     let size = if y.i < x.rng.len: y.i 

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2280,11 +2280,12 @@ proc defineSymbols*() =
         """:
             #=======================================================
             
-            template getUpperLimit(container: (ValueArray|string)): int =
-                if abs(y.i) > container.len: container.len - 1
+            template getUpperLimit(container: untyped): untyped =
+                if abs(y.i) > container.len: container.high
                 else: abs(y.i) - 1
             
-            template take(container :untyped, upperLimit: int): untyped =
+            template take(container: untyped): untyped =
+                let upperLimit: int = container.getUpperLimit()
                 if 0 < y.i:
                     container[0..upperLimit]
                 else:
@@ -2295,12 +2296,10 @@ proc defineSymbols*() =
                 case InPlaced.kind
                 of String:
                     if x.s.len > 0:
-                        let upperLimit: int = InPlaced.s.getUpperLimit()
-                        InPlaced.s = InPlaced.s.take(upperLimit)
+                        InPlaced.s = InPlaced.s.take()
                 of Block:
                     if InPlaced.a.len > 0:
-                        let upperLimit: int = InPlaced.a.getUpperLimit()
-                        InPlaced.a = InPlaced.a.take(upperLimit)
+                        InPlaced.a = InPlaced.a.take()
                 of Range:
                     let size = if y.i < InPlaced.rng.len: y.i 
                                else: InPlaced.rng.len
@@ -2317,13 +2316,11 @@ proc defineSymbols*() =
                 of String:
                     if x.s.len == 0: push(newString(""))
                     else:
-                        let upperLimit: int = x.s.getUpperLimit()
-                        push(newString(x.s.take(upperLimit)))
+                        push(newString(x.s.take()))
                 of Block:
                     if x.a.len == 0: push(newBlock())
                     else:
-                        let upperLimit: int = x.a.getUpperLimit()
-                        push(newBlock(x.a.take(upperLimit)))
+                        push(newBlock(x.a.take()))
                 of Range:
                     let size = if y.i < x.rng.len: y.i 
                                else: x.rng.len

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2250,8 +2250,6 @@ proc defineSymbols*() =
                     push(newBlock(ret))
 
     # TODO(Collections\take) returns SIGSEGV in some cases
-    #  - when y param is 0
-    #  - when y param is greater than a :range x param
     #  - when y param is negative
     builtin "take",
         alias       = unaliased,

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2245,6 +2245,9 @@ proc defineSymbols*() =
                         i += 1
                     push(newBlock(ret))
 
+    # TODO(Collections\take) returns SIGSEGV in some cases
+    #  - when y param is 0
+    #  - when y param is greater than a :range x param
     builtin "take",
         alias       = unaliased,
         op          = opNop,

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -365,8 +365,6 @@ proc defineSymbols*() =
                 let res = unzip(x.a.map((z)=>(requireValue(z,{Block,Inline});(z.a[0], z.a[1]))))
                 push(newBlock(@[newBlock(res[0]), newBlock(res[1])]))
                 
-                
-    # TODO(Collections\drop) returns SIGSEGV when y is a negative number 
 
     builtin "drop",
         alias       = unaliased,

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2301,15 +2301,19 @@ proc defineSymbols*() =
                     if InPlaced.a.len > 0:
                         InPlaced.a = InPlaced.a.take()
                 of Range:
-                    let size = if y.i < InPlaced.rng.len: y.i 
-                               else: InPlaced.rng.len
-                    var res: ValueArray = newSeq[Value](size)
-                    var i = 0
-                    for item in items(InPlaced.rng):
-                        if i == size: break
-                        res[i] = item
-                        i += 1
-                    InPlaced = newBlock(res)
+                    if 0 < y.i:
+                        let upperLimit: int = 
+                            if y.i < InPlaced.rng.len: y.i - 1 
+                            else: InPlaced.rng.len - 1
+                        InPlaced = newBlock(InPlaced.rng[0..upperLimit])
+                    elif 0 > y.i:
+                        let lowerLimit: int = 
+                            if abs(y.i) < InPlaced.rng.len: abs(y.i) - 1
+                            else: InPlaced.rng.len - 1
+                        InPlaced = newBlock(
+                            InPlaced.rng[InPlaced.rng.len-lowerLimit-1..InPlaced.rng.len-1])
+                    else:
+                        InPlaced = newBlock()
                 else: discard
             else:
                 case x.kind
@@ -2322,15 +2326,18 @@ proc defineSymbols*() =
                     else:
                         push(newBlock(x.a.take()))
                 of Range:
-                    let size = if y.i < x.rng.len: y.i 
-                               else: x.rng.len
-                    var res: ValueArray = newSeq[Value](size)
-                    var i = 0
-                    for item in items(x.rng):
-                        if i == size: break
-                        res[i] = item
-                        i += 1
-                    push(newBlock(res))
+                    if 0 < y.i:
+                        let upperLimit: int = 
+                            if y.i < x.rng.len: y.i - 1 
+                            else: x.rng.len - 1
+                        push(newBlock(x.rng[0..upperLimit]))
+                    elif 0 > y.i:
+                        let lowerLimit: int = 
+                            if abs(y.i) < x.rng.len: abs(y.i) - 1
+                            else: x.rng.len - 1
+                        push(newBlock(x.rng[x.rng.len-lowerLimit-1..x.rng.len-1]))
+                    else:
+                        push(newBlock())      
                 else: discard
 
     builtin "tally",

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -2911,31 +2911,113 @@ do [
 
 ]
 
-topic "take"
+topic "take - :string < :string :string"
 do [
-    ensure -> "some" = take "some text" 4   
+    
+    ensure -> "" = take "art" 0
     passed
     
-    ensure -> [Arturo Nim] = take [Arturo Nim C Rust Cobol] 2 
+    ensure -> "a" = take "art" 1
+    ensure -> "ar" = take "art" 2
     passed
     
-    ensure -> [0 1 2 3] = take 0..10 4 
+    ensure -> "art" = take "art" 3
+    ensure -> "art" = take "art" 4
     passed
+    
 ]
 
-topic "take - (literal)"
+topic "take - :string < :string (literal) :string"
 do [
     
-    a: "some text", take 'a 4   
-    ensure -> "some" = a
+    a: "art", take 'a 0
+    ensure -> "" = a
     passed
     
-    a: [Arturo Nim C Rust Cobol], take 'a 2 
-    ensure -> [Arturo Nim] = a
+    a: "art", take 'a 1
+    ensure -> "a" = a
+    a: "art", take 'a 2
+    ensure -> "ar" = a
     passed
     
-    a: 0..10,  take 'a 4 
-    ensure -> [0 1 2 3] = a
+    a: "art", take 'a 3
+    ensure -> "art" = a
+    a: "art", take 'a 4
+    ensure -> "art" = a
+    passed
+    
+]
+
+topic "take - :block < :block :block"
+do [
+    
+    ensure -> [] = take [a b c] 0
+    passed
+    
+    ensure -> [a] = take [a b c] 1
+    ensure -> [a b] = take [a b c] 2
+    passed
+    
+    ensure -> [a b c] = take [a b c] 3
+    ensure -> [a b c] = take [a b c] 4
+    passed
+    
+]
+
+topic "take - :block < :block (literal) :block"
+do [
+    
+    a: [a b c], take 'a 0
+    ensure -> [] = a
+    passed
+    
+    a: [a b c], take 'a 1
+    ensure -> [a] = a
+    a: [a b c], take 'a 2
+    ensure -> [a b] = a
+    passed
+    
+    a: [a b c], take 'a 3
+    ensure -> [a b c] = a
+    a: [a b c], take 'a 4
+    ensure -> [a b c] = a
+    passed
+    
+]
+
+topic "take - :range < :range :integer"
+do [
+    
+    ; ensure -> [] = take 1..3 0
+    ; passed
+    
+    ensure -> [1] = take 1..3 1
+    ensure -> [1 2] = take 1..3 2
+    passed
+    
+    ensure -> [1 2 3] = take 1..3 3
+    ; ensure -> [1 2 3] = take 1..3 4
+    passed
+    
+]
+
+topic "take - :block < :range (literal) :integer"
+do [
+    
+    ; a: 1..3, take 'a 0
+    ; ensure -> [] = a
+    ; passed
+    
+    a: 1..3, take 'a 1
+    ensure -> [1] = a
+    a: 1..3, take 'a 2
+    ensure -> [1 2] = a
+    passed
+    
+    a: 1..3, take 'a 3
+    ensure -> [1 2 3] = a
+    ; a: 1..3, take 'a 4
+    ; ensure -> [1 2 3] = a
     passed
     
 ]

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -3107,6 +3107,17 @@ do [
     ensure -> [1 2 3] = take 1..3 4
     passed
     
+    ensure -> [] = take 1..3 neg 0
+    passed
+    
+    ensure -> [3] = take 1..3 neg 1
+    ensure -> [2 3] = take 1..3 neg 2
+    passed
+    
+    ensure -> [1 2 3] = take 1..3 neg 3
+    ensure -> [1 2 3] = take 1..3 neg 4
+    passed
+    
 ]
 
 topic "take - :block < :range (literal) :integer"
@@ -3125,6 +3136,22 @@ do [
     a: 1..3, take 'a 3
     ensure -> [1 2 3] = a
     a: 1..3, take 'a 4
+    ensure -> [1 2 3] = a
+    passed
+    
+    a: 1..3, take 'a neg 0
+    ensure -> [] = a
+    passed
+    
+    a: 1..3, take 'a neg 1
+    ensure -> [3] = a
+    a: 1..3, take 'a neg 2
+    ensure -> [2 3] = a
+    passed
+    
+    a: 1..3, take 'a neg 3
+    ensure -> [1 2 3] = a
+    a: 1..3, take 'a neg 4
     ensure -> [1 2 3] = a
     passed
     

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -2988,15 +2988,15 @@ do [
 topic "take - :range < :range :integer"
 do [
     
-    ; ensure -> [] = take 1..3 0
-    ; passed
+    ensure -> [] = take 1..3 0
+    passed
     
     ensure -> [1] = take 1..3 1
     ensure -> [1 2] = take 1..3 2
     passed
     
     ensure -> [1 2 3] = take 1..3 3
-    ; ensure -> [1 2 3] = take 1..3 4
+    ensure -> [1 2 3] = take 1..3 4
     passed
     
 ]
@@ -3004,9 +3004,9 @@ do [
 topic "take - :block < :range (literal) :integer"
 do [
     
-    ; a: 1..3, take 'a 0
-    ; ensure -> [] = a
-    ; passed
+    a: 1..3, take 'a 0
+    ensure -> [] = a
+    passed
     
     a: 1..3, take 'a 1
     ensure -> [1] = a
@@ -3016,8 +3016,8 @@ do [
     
     a: 1..3, take 'a 3
     ensure -> [1 2 3] = a
-    ; a: 1..3, take 'a 4
-    ; ensure -> [1 2 3] = a
+    a: 1..3, take 'a 4
+    ensure -> [1 2 3] = a
     passed
     
 ]

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -2979,6 +2979,17 @@ do [
     ensure -> "art" = take "art" 4
     passed
     
+    ensure -> "" = take "art" neg 0
+    passed
+    
+    ensure -> "t" = take "art" neg 1
+    ensure -> "rt" = take "art" neg 2
+    passed
+    
+    ensure -> "art" = take "art" neg 3
+    ensure -> "art" = take "art" neg 4
+    passed
+    
 ]
 
 topic "take - :string < :string (literal) :string"
@@ -3000,6 +3011,22 @@ do [
     ensure -> "art" = a
     passed
     
+    a: "art", take 'a neg 0
+    ensure -> "" = a
+    passed
+    
+    a: "art", take 'a neg 1
+    ensure -> "t" = a
+    a: "art", take 'a neg 2
+    ensure -> "rt" = a
+    passed
+    
+    a: "art", take 'a neg 3
+    ensure -> "art" = a
+    a: "art", take 'a neg 4
+    ensure -> "art" = a
+    passed
+    
 ]
 
 topic "take - :block < :block :block"
@@ -3014,6 +3041,17 @@ do [
     
     ensure -> [a b c] = take [a b c] 3
     ensure -> [a b c] = take [a b c] 4
+    passed
+    
+    ensure -> [] = take [a b c] neg 0
+    passed
+    
+    ensure -> [c] = take [a b c] neg 1
+    ensure -> [b c] = take [a b c] neg 2
+    passed
+    
+    ensure -> [a b c] = take [a b c] neg 3
+    ensure -> [a b c] = take [a b c] neg 4
     passed
     
 ]
@@ -3034,6 +3072,22 @@ do [
     a: [a b c], take 'a 3
     ensure -> [a b c] = a
     a: [a b c], take 'a 4
+    ensure -> [a b c] = a
+    passed
+    
+    a: [a b c], take 'a neg 0
+    ensure -> [] = a
+    passed
+    
+    a: [a b c], take 'a neg 1
+    ensure -> [c] = a
+    a: [a b c], take 'a neg 2
+    ensure -> [b c] = a
+    passed
+    
+    a: [a b c], take 'a neg 3
+    ensure -> [a b c] = a
+    a: [a b c], take 'a neg 4
     ensure -> [a b c] = a
     passed
     

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -480,42 +480,76 @@ do [
 
 topic "drop - :string < :string :string"
 do [
-    ensure -> "rturo" = drop "Arturo" 1
+    
+    ensure -> "art" = drop "art" 0
     passed
-    ensure -> "uro" = drop "Arturo" 3
+    
+    ensure -> "rt" = drop "art" 1
+    ensure -> "t" = drop "art" 2
     passed
+    
+    ensure -> "" = drop "art" 3
+    ensure -> "" = drop "art" 4
+    passed
+    
 ]
 
 topic "drop - :string < :string (literal) :string"
 do [
-    a: "Arturo", drop 'a 1
     
-    ensure -> "rturo" = a
+    a: "art", drop 'a 0
+    ensure -> "art" = a
     passed
     
-    b: "Arturo", drop 'b 3
-    ensure -> "uro" = b
+    a: "art", drop 'a 1
+    ensure -> "rt" = a
+    a: "art", drop 'a 2
+    ensure -> "t" = a
     passed
+    
+    a: "art", drop 'a 3
+    ensure -> "" = a
+    a: "art", drop 'a 4
+    ensure -> "" = a
+    passed
+    
 ]
 
 topic "drop - :block < :block :block"
 do [
-    ensure -> [2 3 4 5] = drop [1 2 3 4 5] 1
+    
+    ensure -> [a b c] = drop [a b c] 0
     passed
-    ensure -> [4 5] = drop [1 2 3 4 5] 3
+    
+    ensure -> [b c] = drop [a b c] 1
+    ensure -> [c] = drop [a b c] 2
     passed
+    
+    ensure -> [] = drop [a b c] 3
+    ensure -> [] = drop [a b c] 4
+    passed
+    
 ]
 
 topic "drop - :block < :block (literal) :block"
 do [
-    a: [1 2 3 4 5], drop 'a 1
     
-    ensure -> [2 3 4 5] = a
+    a: [a b c], drop 'a 0
+    ensure -> [a b c] = a
     passed
     
-    b: [1 2 3 4 5], drop 'b 3
-    ensure -> [4 5] = b
+    a: [a b c], drop 'a 1
+    ensure -> [b c] = a
+    a: [a b c], drop 'a 2
+    ensure -> [c] = a
     passed
+    
+    a: [a b c], drop 'a 3
+    ensure -> [] = a
+    a: [a b c], drop 'a 4
+    ensure -> [] = a
+    passed
+    
 ]
 
 topic "empty - empty?"

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -492,6 +492,17 @@ do [
     ensure -> "" = drop "art" 4
     passed
     
+    ensure -> "art" = drop "art" neg 0
+    passed
+    
+    ensure -> "ar" = drop "art" neg 1
+    ensure -> "a" = drop "art" neg 2
+    passed
+    
+    ensure -> "" = drop "art" neg 3
+    ensure -> "" = drop "art" neg 4
+    passed
+    
 ]
 
 topic "drop - :string < :string (literal) :string"
@@ -513,6 +524,22 @@ do [
     ensure -> "" = a
     passed
     
+    a: "art", drop 'a neg 0
+    ensure -> "art" = a
+    passed
+    
+    a: "art", drop 'a neg 1
+    ensure -> "ar" = a
+    a: "art", drop 'a neg 2
+    ensure -> "a" = a
+    passed
+    
+    a: "art", drop 'a neg 3
+    ensure -> "" = a
+    a: "art", drop 'a neg 4
+    ensure -> "" = a
+    passed
+    
 ]
 
 topic "drop - :block < :block :block"
@@ -527,6 +554,17 @@ do [
     
     ensure -> [] = drop [a b c] 3
     ensure -> [] = drop [a b c] 4
+    passed
+    
+    ensure -> [a b c] = drop [a b c] neg 0
+    passed
+    
+    ensure -> [a b] = drop [a b c] neg 1
+    ensure -> [a] = drop [a b c] neg 2
+    passed
+    
+    ensure -> [] = drop [a b c] neg 3
+    ensure -> [] = drop [a b c] neg 4
     passed
     
 ]
@@ -547,6 +585,22 @@ do [
     a: [a b c], drop 'a 3
     ensure -> [] = a
     a: [a b c], drop 'a 4
+    ensure -> [] = a
+    passed
+    
+    a: [a b c], drop 'a neg 0
+    ensure -> [a b c] = a
+    passed
+    
+    a: [a b c], drop 'a neg 1
+    ensure -> [a b] = a
+    a: [a b c], drop 'a neg 2
+    ensure -> [a] = a
+    passed
+    
+    a: [a b c], drop 'a neg 3
+    ensure -> [] = a
+    a: [a b c], drop 'a neg 4
     ensure -> [] = a
     passed
     

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -165,16 +165,20 @@
 >> drop - :string < :string :string
 [+] passed!
 [+] passed!
+[+] passed!
 
 >> drop - :string < :string (literal) :string
+[+] passed!
 [+] passed!
 [+] passed!
 
 >> drop - :block < :block :block
 [+] passed!
 [+] passed!
+[+] passed!
 
 >> drop - :block < :block (literal) :block
+[+] passed!
 [+] passed!
 [+] passed!
 
@@ -757,13 +761,31 @@
 [+] passed!
 [+] passed!
 
->> take
+>> take - :string < :string :string
 [+] passed!
 [+] passed!
 [+] passed!
 
->> take - (literal)
+>> take - :string < :string (literal) :string
 [+] passed!
+[+] passed!
+[+] passed!
+
+>> take - :block < :block :block
+[+] passed!
+[+] passed!
+[+] passed!
+
+>> take - :block < :block (literal) :block
+[+] passed!
+[+] passed!
+[+] passed!
+
+>> take - :range < :range :integer
+[+] passed!
+[+] passed!
+
+>> take - :block < :range (literal) :integer
 [+] passed!
 [+] passed!
 

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -784,8 +784,10 @@
 >> take - :range < :range :integer
 [+] passed!
 [+] passed!
+[+] passed!
 
 >> take - :block < :range (literal) :integer
+[+] passed!
 [+] passed!
 [+] passed!
 

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -777,8 +777,14 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
 
 >> take - :string < :string (literal) :string
+[+] passed!
+[+] passed!
+[+] passed!
 [+] passed!
 [+] passed!
 [+] passed!
@@ -787,8 +793,14 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
 
 >> take - :block < :block (literal) :block
+[+] passed!
+[+] passed!
+[+] passed!
 [+] passed!
 [+] passed!
 [+] passed!
@@ -797,8 +809,14 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
 
 >> take - :block < :range (literal) :integer
+[+] passed!
+[+] passed!
+[+] passed!
 [+] passed!
 [+] passed!
 [+] passed!

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -166,8 +166,14 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
 
 >> drop - :string < :string (literal) :string
+[+] passed!
+[+] passed!
+[+] passed!
 [+] passed!
 [+] passed!
 [+] passed!
@@ -176,8 +182,14 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
 
 >> drop - :block < :block (literal) :block
+[+] passed!
+[+] passed!
+[+] passed!
 [+] passed!
 [+] passed!
 [+] passed!


### PR DESCRIPTION
# Description

Fixes #1190

`drop` and `take` has some issues to be deal that returns `SIGSEVG`.
I'll care about their parameters as `collection`, the first one, and `number`, the second one.

How I handled these issues:

## When `drop` fails
- [x] When `number` is greater than `collection`'s length
  - ```red
    ; `take` implements this well, look:
    take [1 2 3] 4 ; => [1 2 3]
    drop [1 2 3] 4 ; => []
    ```
- [x] When `number` is negative
  - ```red
    drop [1 2 3] neg 1 ; timeout: sending signal KILL to command '/var/www/arturo-lang.io/arturo-0.9.83-safe-linux'
    ; how should we handle this?
    ```

## When `take` fails
- [x] When `collection` is a `:range` kind and `number` is greater than `collection`'s length
  - ```red
    ; `take` implements this well for other `collection`'s kind, look:
    take [1 2 3] 4 ; => [1 2 3]
    take 1..3 4 ; => [1 2 3]
    ```
- [x] When `collection` is a `:range` kind and `number` is 0
  - ```red
    ; `take` implements this well for other `collection`'s kind, look:
    take [1 2 3] 0 ; => []
    take 1..3 0 ; => []
    ```
- [x] When `number` is negative
  - ```red
    take [1 2 3] neg 1 ; timeout: sending signal KILL to command '/var/www/arturo-lang.io/arturo-0.9.83-safe-linux'
    ; how should we handle this?
    ```

## Type of change

- [x] Code cleanup
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Update documentation
- [x] Add/Update unit-tests