### PR TITLE
[Numbers] add rational supports to its functions

### DIFF
--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -1168,7 +1168,7 @@ proc defineSymbols*() =
         attrs       = {
             "cartesian"  : ({Logical},"return the cartesian product of given sublists")
         },
-        returns     = {Integer,Floating},
+        returns     = {Integer,Floating,Rational},
         example     = """
             print product [3 4]       ; 12
             print product [1 2 4 6]   ; 48

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -1451,7 +1451,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the hyperbolic tangent of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -239,7 +239,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the inverse secant of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -302,7 +302,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the inverse hyperbolic sine of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -159,7 +159,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the inverse hyperbolic cosecant of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -180,7 +180,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the inverse cotangent of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -117,7 +117,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the inverse hyperbolic cosine of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -344,8 +344,8 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the inverse tangent of y / x",
         args        = {
-            "y"     : {Integer,Floating},
-            "x"     : {Integer,Floating}
+            "y"     : {Integer,Floating,Rational},
+            "x"     : {Integer,Floating,Rational}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -260,7 +260,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the inverse hyperbolic secant of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -201,7 +201,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the inverse hyperbolic cotangent of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -1201,8 +1201,8 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "get a random integer between given limits",
         args        = {
-            "lowerLimit"    : {Integer, Floating},
-            "upperLimit"    : {Integer, Floating}
+            "lowerLimit"    : {Integer, Floating, Rational},
+            "upperLimit"    : {Integer, Floating, Rational}
         },
         attrs       = NoAttrs,
         returns     = {Integer, Floating},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -537,7 +537,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the hyperbolic cosecant of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -796,7 +796,7 @@ proc defineSymbols*() =
             rule        = PrefixPrecedence,
             description = "calculate the gamma function for given value",
             args        = {
-                "value" : {Integer,Floating}
+                "value" : {Integer,Floating,Rational}
             },
             attrs       = NoAttrs,
             returns     = {Floating},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -53,9 +53,6 @@ template processTrigonometric(fun: untyped): untyped =
 
 # TODO(Numbers) add `tau` constant
 #  labels:library, new feature
-
-# TODO(Numbers) add support to `:rational`to necessary functions
-#   labels:library, new feature, open discussion
  
 proc defineSymbols*() =
 

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -1281,7 +1281,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the secant of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -1323,7 +1323,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the sine of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -495,7 +495,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the hyperbolic cosine of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -854,8 +854,8 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the hypotenuse of a right-angle triangle with given base and height",
         args        = {
-            "base"  : {Integer,Floating},
-            "height": {Integer,Floating}
+            "base"  : {Integer,Floating,Rational},
+            "height": {Integer,Floating,Rational}
         },
         attrs       = NoAttrs,
         returns     = {Floating},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -579,7 +579,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the hyperbolic cotangent of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -969,8 +969,8 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the logarithm of value using given base",
         args        = {
-            "value" : {Integer,Floating},
-            "base"  : {Integer,Floating}
+            "value" : {Integer,Floating,Rational},
+            "base"  : {Integer,Floating,Rational}
         },
         attrs       = NoAttrs,
         returns     = {Floating},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -558,7 +558,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the cotangent of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -474,7 +474,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the cosine of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -1344,7 +1344,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the hyperbolic sine of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -516,7 +516,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the cosecant of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -138,7 +138,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the inverse cosecant of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -362,7 +362,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the inverse hyperbolic tangent of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -96,7 +96,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the inverse cosine of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -1404,7 +1404,7 @@ proc defineSymbols*() =
             "collection"    : {Block,Range}
         },
         attrs       = NoAttrs,
-        returns     = {Integer,Floating},
+        returns     = {Integer,Floating,Rational},
         example     = """
             print sum [3 4]           ; 7
             print sum [1 2 4 6]       ; 13

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -1369,7 +1369,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "get square root of given value",
         args        = {
-            "value" : {Integer,Floating,Complex}
+            "value" : {Integer,Floating,Complex,Rational}
         },
         attrs       = {
             "integer"   : ({Logical},"get the integer square root")

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -690,7 +690,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the exponential function for given value",
         args        = {
-            "value" : {Integer,Floating,Complex}
+            "value" : {Integer,Floating,Complex,Rational}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -323,7 +323,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the inverse tangent of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -947,7 +947,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the natural logarithm of given value",
         args        = {
-            "value" : {Integer,Floating,Complex}
+            "value" : {Integer,Floating,Complex,Rational}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -281,7 +281,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the inverse sine of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -1430,7 +1430,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the tangent of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},

--- a/src/library/Numbers.nim
+++ b/src/library/Numbers.nim
@@ -1302,7 +1302,7 @@ proc defineSymbols*() =
         rule        = PrefixPrecedence,
         description = "calculate the hyperbolic secant of given angle",
         args        = {
-            "angle" : {Integer,Floating,Complex,Quantity}
+            "angle" : {Integer,Floating,Complex,Rational,Quantity}
         },
         attrs       = NoAttrs,
         returns     = {Floating,Complex},


### PR DESCRIPTION
# Description

I did minimal changes on it, just adding `Rational` type to argument list into functions that I think that should support them, and adding it to return list too for functions that already returns a `:rational` but it's not annotated.
Also, I did not need to change anything more, since these functions are using `asFloat` internally, and returning a `:floating` at the end.

* Fixes #1185

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update