### PR TITLE
[Comparison\between?] add support for order insensitive limits

### DIFF
--- a/src/library/Comparison.nim
+++ b/src/library/Comparison.nim
@@ -54,9 +54,12 @@ proc defineSymbols*() =
             between? 1 2 3      ; => false
             between? 2 0 3      ; => true
             between? 3 2 3      ; => true
+            between? 3 3 2      ; => true
 
             1 <=> 2 3           ; => false
+            1 <=> 3 2           ; => false
             2 <=> 0 3           ; => true
+            2 <=> 3 0           ; => true
             3 <=> 2 3           ; => true  
         """:
             #=======================================================

--- a/src/library/Comparison.nim
+++ b/src/library/Comparison.nim
@@ -60,14 +60,14 @@ proc defineSymbols*() =
             3 <=> 2 3           ; => true  
         """:
             #=======================================================
-            if x < y: 
-                push VFALSE
-                return
-            if x > z:
-                push VFALSE
-                return
-
-            push VTRUE
+            template isBetween(target, lower, upper: untyped) =
+                if target < lower or target > upper:
+                    push VFALSE
+                else:
+                    push VTRUE
+        
+            if y < z: x.isBetween(y, z)
+            else: x.isBetween(z, y)
 
     # TODO(Comparison/compare) verify it's working right
     #  The main problem seems to be this vague `else:`.

--- a/src/library/Comparison.nim
+++ b/src/library/Comparison.nim
@@ -32,12 +32,6 @@ proc defineSymbols*() =
     #  But: we'll obviously have to somehow "define" this... approximate equality.
     #  labels: library, enhancement, open discussion
 
-    # TODO(Comparison/between?) add support for order-insensitive range limits?
-    #  since `between?` takes two values, we could in theory support any two values, regardless of their order.
-    #  right now, the two values `rangeFrom` and `rangeTo` have to be in order, that is rangeFrom < rangeTo.
-    #  It doesn't make too much sense for the purpose of this function, I think!
-    #  see also: https://github.com/arturo-lang/arturo/pull/1139
-    #  labels: library, enhancement, open discussion
     builtin "between?",
         alias       = thickarrowboth, 
         op          = opNop,

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -648,6 +648,49 @@ do [
     
 ]
 
+topic « between? - test with reversed index
+do [
+ 
+    ; NOTE: as between? is agnostic to types, 
+    ; and the reversed order works via untyped template, 
+    ; this test works for every single test already tested above.
+    ; So, I'll not re-implement everything again, since it's not necessary.
+    
+    ensure -> between? 1 2                  1
+    ensure -> between? 1 2.0                1
+    ensure -> between? 1 to :rational [2 1] 1
+    ensure -> between? 1 2                  1.0
+    ensure -> between? 1 2.0                1.0
+    ensure -> between? 1 to :rational [2 1] 1.0
+    ensure -> between? 1 2                  to :rational [1 1]
+    ensure -> between? 1 2.0                to :rational [1 1]
+    ensure -> between? 1 to :rational [2 1] to :rational [1 1]
+    passed
+    
+    ensure -> between? 1 2                  0
+    ensure -> between? 1 2.0                0
+    ensure -> between? 1 to :rational [2 1] 0
+    ensure -> between? 1 2                  0.0
+    ensure -> between? 1 2.0                0.0
+    ensure -> between? 1 to :rational [2 1] 0.0
+    ensure -> between? 1 2                  to :rational [0 1]
+    ensure -> between? 1 2.0                to :rational [0 1]
+    ensure -> between? 1 to :rational [2 1] to :rational [0 1]
+    passed
+
+    ensure -> not? between? 0 2                     1
+    ensure -> not? between? 0 2.0                   1
+    ensure -> not? between? 0 to :rational [2 1]    1
+    ensure -> not? between? 0 2                     1.0
+    ensure -> not? between? 0 2.0                   1.0
+    ensure -> not? between? 0 to :rational [2 1]    1.0
+    ensure -> not? between? 0 2                     to :rational [1 1]
+    ensure -> not? between? 0 2.0                   to :rational [1 1]
+    ensure -> not? between? 0 to :rational [2 1]    to :rational [1 1]
+    passed
+    
+]
+
 
 topic « compare
 do [

--- a/tests/unittests/lib.comparison.res
+++ b/tests/unittests/lib.comparison.res
@@ -96,6 +96,11 @@
 >> between? - :date
 [+] passed!
 
+>> between? - test with reversed index
+[+] passed!
+[+] passed!
+[+] passed!
+
 >> compare
 
 >> compare - :integer :floating :rational


### PR DESCRIPTION
# Description
Adds support to order insensitive range limits.
Basically, `between?` has 3 arguments: `value`, `rangeFrom` and `rangeTo`. 
So why `rangeFrom` can't be greater than `rangeTo`? So, I'm implementing this.

* Fixes #1146

## Type of change

- [x] Code cleanup
- [x] New feature (non-breaking change which adds functionality)
- [x] Add/Update unit-tests
- [x] This change requires a documentation update