### PR TITLE
[Comparisons\between?] fix behavior

### DIFF
--- a/src/library/Comparison.nim
+++ b/src/library/Comparison.nim
@@ -58,10 +58,10 @@ proc defineSymbols*() =
         """:
             #=======================================================
             template isBetween(target, lower, upper: untyped) =
-                if target < lower or target > upper:
-                    push VFALSE
-                else:
+                if (target == lower or target == upper) or (target > lower and target < upper):
                     push VTRUE
+                else:
+                    push VFALSE
         
             if y < z: x.isBetween(y, z)
             else: x.isBetween(z, y)

--- a/tests/unittests/lib.comparison.art
+++ b/tests/unittests/lib.comparison.art
@@ -581,11 +581,11 @@ do [
     ensure -> between? a a #[name: "Jesse" surname: "Pinkman"]
     ensure -> between? a a #[name: "Walter" surname: "Pinkman" age: 35]
     ensure -> between? a a #[name: "Zalter" surname: "Rinkman"]
-    ensure -> between? #[name: "Walter"] 
+    ensure -> not? between? #[name: "Walter"] 
         a #[name: "Walter" surname: "Pinkman" age: 35]
-    ensure -> between? a #[name: "Jesse" surname: "Pinkman"] #[name: "Zalter" surname: "Rinkman"]
-    ; ensure -> between? #[name: "Zalter" surname: "Rinkman"] 
-    ;     #[name: "Jesse" surname: "Pinkman"] #[name: "Walter" surname: "Pinkman"]
+    ensure -> not? between? a #[name: "Jesse" surname: "Pinkman"] #[name: "Zalter" surname: "Rinkman"]
+    ensure -> not? between? #[name: "Zalter" surname: "Rinkman"] 
+        #[name: "Jesse" surname: "Pinkman"] #[name: "Walter" surname: "Pinkman"]
     passed
     
     
@@ -621,8 +621,8 @@ do [
     ensure -> between? to :person ["John" 16] b a
     ensure -> between? to :person ["John" 15] c d
     ensure -> between? to :person ["John" 15] d c
-    ; ensure -> not? between? to :person ["John" 14] c a
-    ; ensure -> not? between? to :person ["John" 17] c a
+    ensure -> not? between? to :person ["John" 14] c a
+    ensure -> not? between? to :person ["John" 17] c a
     passed
     
     
@@ -652,9 +652,8 @@ do [
     ensure -> between? `EUR `USD `EUR
     passed
     
-    ; TODO: fix me soon
-    ; ensure -> not? between? `BRL `USD `EUR
-    ; passed    
+    ensure -> not? between? `BRL `USD `EUR
+    passed    
     
 ]
 

--- a/tests/unittests/lib.comparison.res
+++ b/tests/unittests/lib.comparison.res
@@ -98,6 +98,7 @@
 
 >> between? - :unit
 [+] passed!
+[+] passed!
 
 >> between? - test with reversed index
 [+] passed!


### PR DESCRIPTION
# Description

Fix `between?` behavior. It was returning true for some values unsupported by `<`/`>` comparisons.
I worked very well then for number-kind values, but for other types, does not.

I discovered that when I was doing the PR #1209.

The new algorithm takes more steps, but it will work well for every cases.

- Fixes #1213

## Type of change

- [ ] Code cleanup
- [x] Unit tests (added or updated unit-tests)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (documentation-related additions)