### PR TITLE
[helpers\webview] Properly raise error for browser related things

### DIFF
--- a/src/helpers/webviews.nim
+++ b/src/helpers/webviews.nim
@@ -137,7 +137,7 @@ proc openChromeWindow*(port: int, flags: seq[string] = @[]) =
     #  with a proper error being thrown and declared in VM/errors
     #  labels: enhancement, error handling
     if chromePath == "":
-        echo "could not find any Chrome-compatible browser installed"
+        RuntimeError_CompatibleBrowserNotFound()
     else:
         let command = chromePath.replace(" ", r"\ ") & " " & args.join(" ")
         if execCmd(command) != 0:

--- a/src/helpers/webviews.nim
+++ b/src/helpers/webviews.nim
@@ -138,7 +138,7 @@ proc openChromeWindow*(port: int, flags: seq[string] = @[]) =
     else:
         let command = chromePath.replace(" ", r"\ ") & " " & args.join(" ")
         if execCmd(command) != 0:
-            echo "could not open a Chrome window"
+            RuntimeError_CompatibleBrowserCouldNotOpenWindow()
 
 when not defined(NOWEBVIEW):
 

--- a/src/helpers/webviews.nim
+++ b/src/helpers/webviews.nim
@@ -11,6 +11,7 @@
 #=======================================
 
 import os, osproc, strutils
+import vm/errors
 
 when not defined(NOWEBVIEW):
     import std/json
@@ -21,7 +22,6 @@ when not defined(NOWEBVIEW):
     import helpers/jsonobject
     import helpers/windows
     import vm/values/value
-    import vm/errors
 
     export webview
 

--- a/src/helpers/webviews.nim
+++ b/src/helpers/webviews.nim
@@ -21,6 +21,7 @@ when not defined(NOWEBVIEW):
     import helpers/jsonobject
     import helpers/windows
     import vm/values/value
+    import vm/errors
 
     export webview
 
@@ -132,10 +133,6 @@ proc openChromeWindow*(port: int, flags: seq[string] = @[]) =
             chromePath = bin
             break
 
-    # TODO(Helpers/webviews) should produce valid error messages
-    #  currently, we are just outputing a string. Preferrable, it should be done
-    #  with a proper error being thrown and declared in VM/errors
-    #  labels: enhancement, error handling
     if chromePath == "":
         RuntimeError_CompatibleBrowserNotFound()
     else:

--- a/src/vm/errors.nim
+++ b/src/vm/errors.nim
@@ -400,7 +400,7 @@ proc RuntimeError_CompatibleBrowserNotFound*() =
           
 proc RuntimeError_CompatibleBrowserCouldNotOpenWindow*() =
     panic RuntimeError,
-          "could not open a Chrome-compatible browser's window"
+          "could not open a Chrome-compatible browser window"
 
 
 # Program errors

--- a/src/vm/errors.nim
+++ b/src/vm/errors.nim
@@ -393,6 +393,10 @@ proc RuntimeError_ConfigNotFound*(gkey: string, akey: string) =
 proc RuntimeError_RangeWithZeroStep*() =
     panic RuntimeError,
           "attribute step can't be 0"
+          
+proc RuntimeError_CompatibleBrowserNotFound*() =
+    panic RuntimeError,
+          "could not find any Chrome-compatible browser installed"
 
 
 # Program errors

--- a/src/vm/errors.nim
+++ b/src/vm/errors.nim
@@ -397,6 +397,10 @@ proc RuntimeError_RangeWithZeroStep*() =
 proc RuntimeError_CompatibleBrowserNotFound*() =
     panic RuntimeError,
           "could not find any Chrome-compatible browser installed"
+          
+proc RuntimeError_CompatibleBrowserCouldNotOpenWindow*() =
+    panic RuntimeError,
+          "could not open a Chrome-compatible browser's window"
 
 
 # Program errors


### PR DESCRIPTION
# Description

Add a proper error throw, instead of print it on the terminal.

Summary:
- Creates `RuntimeError_CompatibleBrowserNotFound`: when the compatible browser is not found, it raises an error
- Creates `RuntimeError_CompatibleBrowserCouldNotOpenWindow`: when the compatible browser can't open a window, it raises an error
- Replaces all `echo "some error message"` by these respective runtime errors.

----

- Fixes #1222

## Type of change

- [x] Enhancement (implementation update, or general performance enhancements)