### PR TITLE
[Converters\dictionary] properly raise error when file not found

### DIFF
--- a/src/library/Converters.nim
+++ b/src/library/Converters.nim
@@ -924,7 +924,7 @@ proc defineSymbols*() =
                     #  currently, we are just outputing a string. Preferrable, it should be done
                     #  with a proper error being thrown and declared in VM/errors
                     #  labels: enhancement, error handling
-                    echo "file does not exist"
+                    RuntimeError_FileNotFound(x.s)
 
             if checkAttr("with"):
                 for x in aWith.a:

--- a/src/library/Converters.nim
+++ b/src/library/Converters.nim
@@ -920,10 +920,6 @@ proc defineSymbols*() =
                 if tp!=TextData:
                     dict = execDictionary(doParse(src, isFile=false))#, isIsolated=true)
                 else:
-                    # TODO(Converters/dictionary) should produce valid error messages
-                    #  currently, we are just outputing a string. Preferrable, it should be done
-                    #  with a proper error being thrown and declared in VM/errors
-                    #  labels: enhancement, error handling
                     RuntimeError_FileNotFound(x.s)
 
             if checkAttr("with"):

--- a/tests/errors/runtime.FileNotFound.2.art
+++ b/tests/errors/runtime.FileNotFound.2.art
@@ -1,0 +1,1 @@
+dictionary "./test"

--- a/tests/errors/runtime.FileNotFound.2.res
+++ b/tests/errors/runtime.FileNotFound.2.res
@@ -1,0 +1,4 @@
+>> Runtime | File: runtime.FileNotFound.2.art
+     error | Line: 1
+           | 
+           | file not found: ./test


### PR DESCRIPTION
# Description

Summary:
- Replace echo by `RuntimeError_FileNotFound`

---

- Fixes #1224

## Type of change

- [x] Unit tests (added or updated unit-tests)
- [x] Enhancement (implementation update, or general performance enhancements)