### PR TITLE
Net/serve: minor fix

### DIFF
--- a/src/library/internal/Net/serve.art
+++ b/src/library/internal/Net/serve.art
@@ -58,13 +58,12 @@ serveInternal: function [Request, verbose][
     callActionFunction: function [actionFunc, ptrn][
         actionParams: keys get info.get 'actionFunc 'args
         passedParams: new []
-
         if positive? size actionParams [
-            matchedGroups: match.capture Request\path ptrn
+            matchedGroups: first match.named.capture Request\path ptrn
             loop actionParams 'actionParam [
                 if and? [dictionary? Request\body][key? Request\body actionParam] ->
                     'passedParams ++ Request\body\[actionParam]
-                
+
                 if key? Request\query actionParam ->
                     'passedParams ++ Request\query\[actionParam]
 


### PR DESCRIPTION
# Description

Apparently, `match` options have been changed and we must update the internal implementation so that everything keeps working like before.

Probably provides a fix for #1239 ?

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)