### PR TITLE
[Helpers\charset] add Vietnamese alphabet support

### DIFF
--- a/src/helpers/charsets.nim
+++ b/src/helpers/charsets.nim
@@ -18,9 +18,6 @@ import vm/values/value
 # Constants
 #=======================================
 
-# TODO(Strings\alphabet) add support for Vietnamese alphabet -> vi
-#  label: library, enhancement, easy
-
 const
     NgraphReplacement = "%".runeAt(0)
 

--- a/src/helpers/charsets.nim
+++ b/src/helpers/charsets.nim
@@ -110,7 +110,7 @@ const
         "sk": "dz,dž,ch",
         "sq": "dh,gj,ll,nj,rr,sh,th,xh,zh",
         "tl": "ng",
-        "vi": "gi,kh,ng,nh,ph,qu,th,tr,"
+        "vi": "gi,kh,ng,nh,ph,qu,th,tr"
     }.toTable
 
 #=======================================

--- a/src/helpers/charsets.nim
+++ b/src/helpers/charsets.nim
@@ -76,7 +76,8 @@ const
         "sw": "abcdefghijklmnoprstuvwyz",
         "tl": "abcdefghijklmnñ%opqrstuvwxyz",
         "tr": "abcçdefgğhıijklmnoöprsştuüvyz",
-        "uk": "абвгґдеєжзиіїйклмнопрстуфхцчшщьюя"
+        "uk": "абвгґдеєжзиіїйклмнопрстуфхцчшщьюя",
+        "vi": "aăâbcdđeêghiklmnoôơprtuưvxy",
     }.toTable
 
     # extra characters that can be found in a given language, by ISO 639-1 code,
@@ -96,7 +97,8 @@ const
         "it": "àéèíìîóòúù",
         "pt": "áàâãäçéêëíïóõöúü",
         "ru": "а́е́и́о́у́э́",
-        "sl": "áȃȁćđéèȇẹ́ẹ̑ȅíȋȉóȏọ́ọ̑ȍqŕȓúȗȕwxy"
+        "sl": "áȃȁćđéèȇẹ́ẹ̑ȅíȋȉóȏọ́ọ̑ȍqŕȓúȗȕwxy",
+        "vi": "áắấàằầảẳẩãẵẫạặậéếèềẻểẽễẹệíìỉĩịóốớòồờỏổởõỗỡọộợúứùừủửũữụựýỳỷỹỵ",
     }.toTable
 
     # di- or tri-graphs that can be found in a given language, by ISO 639-1 code,
@@ -110,7 +112,8 @@ const
         "mt": "għ,ie",
         "sk": "dz,dž,ch",
         "sq": "dh,gj,ll,nj,rr,sh,th,xh,zh",
-        "tl": "ng"
+        "tl": "ng",
+        "vi": "gi,kh,ng,nh,ph,qu,th,tr,"
     }.toTable
 
 #=======================================


### PR DESCRIPTION
# Description

Add Vietnamese support, based on: [_Vietnamese language_ by Wikipedia, 2023][wiki-vi] and [_How to Learn the Vietnamese Alphabet: An In-Depth Guide_ by Julian, 2021][f3m]

- Fixes #558

## Type of change
- [x] Enhancement (implementation update, or general performance enhancements)

[wiki-vi]: https://en.wikipedia.org/wiki/Vietnamese_language
[f3m]: https://www.fluentin3months.com/vietnamese-alphabet/