### PR TITLE
Enable and 32-bits (x86 and ARM32) builds

### DIFF
--- a/.config/arch.nims
+++ b/.config/arch.nims
@@ -11,6 +11,7 @@ proc arm64Config() =
     --gcc.linkerexe:"aarch64-linux-gnu-gcc"
     
 proc x86Config() =
+    --verbosity:3
     --cpu:i386 
     --define:bit32
     if defined(gcc): 
@@ -18,6 +19,7 @@ proc x86Config() =
         --passL:"'-m32'"
         
 proc arm32Config() = 
+    --verbosity:3
     --cpu:arm 
     --define:bit32
     

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,7 +35,7 @@ jobs:
         arch:
           #- x86
           - amd64
-          #- arm
+          - arm
           - arm64
         exclude:
           - version: full


### PR DESCRIPTION
# Description

32-bits builds are disabled by about of 6 months. So, let's try to make it work again.

> Note: 32-bits builds works just for `@MINI` variants.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)