### PR TITLE
[VM\value\comparison]: Clear comparisons with `getValuePair`

### DIFF
--- a/bench
+++ b/bench
@@ -2,7 +2,15 @@
 
 git log -n 1 --pretty=medium > bench-log
 
-{ time ./bin/arturo.exe ./tools/tester.art; } 2>> bench-log
+echo -e "\nOLD" >> bench-log
+{ 
+    time ./bin/reference.exe ./tests/unittests/lib.comparison.art; 
+} 2>> bench-log
+
+echo -e "\nCURRENT" >> bench-log
+{ 
+    time ./bin/arturo.exe ./tests/unittests/lib.comparison.art; 
+} 2>> bench-log
 
 git add bench-log
 git commit -m "[bench]: update benchmark's log"

--- a/bench
+++ b/bench
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+git log -n 1 --pretty=medium > bench-log
+
+{ time ./bin/arturo.exe ./tools/tester.art; } 2>> bench-log
+
+git add bench-log
+git commit -m "[bench]: update benchmark's log"

--- a/bench
+++ b/bench
@@ -5,14 +5,14 @@ git log -n 1 --pretty=medium > bench-log
 
 echo -e "\nOLD" >> bench-log
 { 
-    time for counter in {1..50} 
+    time for counter in {1..250} 
     do ./bin/reference.exe ./tests/unittests/lib.comparison.art
     done;
 } 2>> bench-log
 
 echo -e "\nCURRENT" >> bench-log
 { 
-    time for counter in {1..50} 
+    time for counter in {1..250} 
     do ./bin/arturo.exe ./tests/unittests/lib.comparison.art
     done; 
 } 2>> bench-log

--- a/bench
+++ b/bench
@@ -4,12 +4,16 @@ git log -n 1 --pretty=medium > bench-log
 
 echo -e "\nOLD" >> bench-log
 { 
-    time ./bin/reference.exe ./tests/unittests/lib.comparison.art; 
+    time for counter in {1..50} 
+    do ./bin/reference.exe ./tests/unittests/lib.comparison.art
+    done;
 } 2>> bench-log
 
 echo -e "\nCURRENT" >> bench-log
 { 
-    time ./bin/arturo.exe ./tests/unittests/lib.comparison.art; 
+    time for counter in {1..50} 
+    do ./bin/arturo.exe ./tests/unittests/lib.comparison.art
+    done; 
 } 2>> bench-log
 
 git add bench-log

--- a/bench
+++ b/bench
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+./build.nims --log 
 git log -n 1 --pretty=medium > bench-log
 
 echo -e "\nOLD" >> bench-log

--- a/bench-log
+++ b/bench-log
@@ -1,19 +1,17 @@
-commit 3ffc3675a643801b8337eca16b84ee49382574db
+commit 82ff23335307a63a6e93ab0cddea8869cfabf85f
 Author: RickBarretto <78623871+RickBarretto@users.noreply.github.com>
-Date:   Sat Dec 23 22:14:06 2023 -0300
+Date:   Sat Dec 23 22:14:46 2023 -0300
 
-    [bench]: modify custom temporary benchmarker
-    
-    Comparing using a reference instead
+    [bench]: update benchmark's log
 
 OLD
 
-real	0m1.791s
+real	0m1.875s
 user	0m0.000s
-sys	0m0.015s
+sys	0m0.000s
 
 CURRENT
 
-real	0m1.945s
-user	0m0.015s
+real	0m2.183s
+user	0m0.000s
 sys	0m0.000s

--- a/bench-log
+++ b/bench-log
@@ -1,17 +1,17 @@
-commit 82ff23335307a63a6e93ab0cddea8869cfabf85f
+commit e7f3347057b028118825df09312065442419921d
 Author: RickBarretto <78623871+RickBarretto@users.noreply.github.com>
-Date:   Sat Dec 23 22:14:46 2023 -0300
+Date:   Sat Dec 23 22:14:52 2023 -0300
 
     [bench]: update benchmark's log
 
 OLD
 
-real	0m1.875s
+real	0m1.780s
 user	0m0.000s
 sys	0m0.000s
 
 CURRENT
 
-real	0m2.183s
+real	0m2.450s
 user	0m0.000s
 sys	0m0.000s

--- a/bench-log
+++ b/bench-log
@@ -1,17 +1,17 @@
-commit 2eace1050dced7ce54c9f28b9b99901f3edcd51c
+commit be8aaf74aba9443a2eaef44ae9afc0a2ec68ee7e
 Author: RickBarretto <78623871+RickBarretto@users.noreply.github.com>
-Date:   Sun Dec 24 00:02:22 2023 -0300
+Date:   Sun Dec 24 17:18:16 2023 -0300
 
-    [VM\values\comparison]: minor fix
+    [VM\values\comparison]: use `getValuePair` for non numeric types for `<`
 
 OLD
 
-real	1m11.236s
-user	0m0.030s
-sys	0m0.136s
+real	1m42.013s
+user	0m0.075s
+sys	0m0.106s
 
 CURRENT
 
-real	1m16.390s
-user	0m0.000s
-sys	0m0.107s
+real	1m41.344s
+user	0m0.046s
+sys	0m0.228s

--- a/bench-log
+++ b/bench-log
@@ -1,0 +1,9 @@
+commit 4db240ef8a1fad04752d22a800c6f66bc17f6ef4
+Author: RickBarretto <78623871+RickBarretto@users.noreply.github.com>
+Date:   Sat Dec 23 19:39:16 2023 -0300
+
+    [bench]: add custom temporary benchmarker
+
+real	4m41.062s
+user	0m0.015s
+sys	0m0.000s

--- a/bench-log
+++ b/bench-log
@@ -1,17 +1,17 @@
-commit 8fa3d1bb743fd10de0302d9b2cc29ba1430f4b4d
+commit 1ec6347477e5e646aae23a1e677862705c5f447b
 Author: RickBarretto <78623871+RickBarretto@users.noreply.github.com>
-Date:   Sun Dec 24 17:39:55 2023 -0300
+Date:   Sun Dec 24 18:51:12 2023 -0300
 
-    [bench]: up the amount of samples to 250
+    [VM\values\comparison]: minor fix
 
 OLD
 
-real	9m24.590s
-user	0m0.362s
-sys	0m0.973s
+real	9m2.314s
+user	0m0.332s
+sys	0m0.809s
 
 CURRENT
 
-real	8m52.531s
-user	0m0.454s
-sys	0m0.955s
+real	8m35.180s
+user	0m0.181s
+sys	0m0.842s

--- a/bench-log
+++ b/bench-log
@@ -1,17 +1,17 @@
-commit be8aaf74aba9443a2eaef44ae9afc0a2ec68ee7e
+commit 87f5eff630e53fd2f1863153176e2ae22387f18e
 Author: RickBarretto <78623871+RickBarretto@users.noreply.github.com>
-Date:   Sun Dec 24 17:18:16 2023 -0300
+Date:   Sun Dec 24 17:27:16 2023 -0300
 
-    [VM\values\comparison]: use `getValuePair` for non numeric types for `<`
+    [VM\values\comparison]: use `getValuePair` for all types for `>`
 
 OLD
 
-real	1m42.013s
-user	0m0.075s
+real	1m49.366s
+user	0m0.030s
 sys	0m0.106s
 
 CURRENT
 
-real	1m41.344s
-user	0m0.046s
-sys	0m0.228s
+real	1m42.999s
+user	0m0.060s
+sys	0m0.243s

--- a/bench-log
+++ b/bench-log
@@ -1,9 +1,19 @@
-commit 4db240ef8a1fad04752d22a800c6f66bc17f6ef4
+commit 3ffc3675a643801b8337eca16b84ee49382574db
 Author: RickBarretto <78623871+RickBarretto@users.noreply.github.com>
-Date:   Sat Dec 23 19:39:16 2023 -0300
+Date:   Sat Dec 23 22:14:06 2023 -0300
 
-    [bench]: add custom temporary benchmarker
+    [bench]: modify custom temporary benchmarker
+    
+    Comparing using a reference instead
 
-real	4m41.062s
+OLD
+
+real	0m1.791s
+user	0m0.000s
+sys	0m0.015s
+
+CURRENT
+
+real	0m1.945s
 user	0m0.015s
 sys	0m0.000s

--- a/bench-log
+++ b/bench-log
@@ -1,17 +1,17 @@
-commit 87f5eff630e53fd2f1863153176e2ae22387f18e
+commit 8fa3d1bb743fd10de0302d9b2cc29ba1430f4b4d
 Author: RickBarretto <78623871+RickBarretto@users.noreply.github.com>
-Date:   Sun Dec 24 17:27:16 2023 -0300
+Date:   Sun Dec 24 17:39:55 2023 -0300
 
-    [VM\values\comparison]: use `getValuePair` for all types for `>`
+    [bench]: up the amount of samples to 250
 
 OLD
 
-real	1m49.366s
-user	0m0.030s
-sys	0m0.106s
+real	9m24.590s
+user	0m0.362s
+sys	0m0.973s
 
 CURRENT
 
-real	1m42.999s
-user	0m0.060s
-sys	0m0.243s
+real	8m52.531s
+user	0m0.454s
+sys	0m0.955s

--- a/bench-log
+++ b/bench-log
@@ -1,17 +1,19 @@
-commit e7f3347057b028118825df09312065442419921d
+commit bd21c2a9114696d34efca40767ea55b7361fb9f5
 Author: RickBarretto <78623871+RickBarretto@users.noreply.github.com>
-Date:   Sat Dec 23 22:14:52 2023 -0300
+Date:   Sat Dec 23 22:28:31 2023 -0300
 
-    [bench]: update benchmark's log
+    [bench]: modify custom temporary benchmarker
+    
+    Run 50x per binary
 
 OLD
 
-real	0m1.780s
-user	0m0.000s
-sys	0m0.000s
+real	1m18.964s
+user	0m0.136s
+sys	0m0.075s
 
 CURRENT
 
-real	0m2.450s
-user	0m0.000s
-sys	0m0.000s
+real	1m21.691s
+user	0m0.030s
+sys	0m0.245s

--- a/bench-log
+++ b/bench-log
@@ -1,19 +1,17 @@
-commit bd21c2a9114696d34efca40767ea55b7361fb9f5
+commit 2eace1050dced7ce54c9f28b9b99901f3edcd51c
 Author: RickBarretto <78623871+RickBarretto@users.noreply.github.com>
-Date:   Sat Dec 23 22:28:31 2023 -0300
+Date:   Sun Dec 24 00:02:22 2023 -0300
 
-    [bench]: modify custom temporary benchmarker
-    
-    Run 50x per binary
+    [VM\values\comparison]: minor fix
 
 OLD
 
-real	1m18.964s
-user	0m0.136s
-sys	0m0.075s
+real	1m11.236s
+user	0m0.030s
+sys	0m0.136s
 
 CURRENT
 
-real	1m21.691s
-user	0m0.030s
-sys	0m0.245s
+real	1m16.390s
+user	0m0.000s
+sys	0m0.107s

--- a/src/vm/values/comparison.nim
+++ b/src/vm/values/comparison.nim
@@ -298,46 +298,39 @@ proc `<`*(x: Value, y: Value): bool {.inline.}=
         of BigInteger       || Floating         :   (when GMP: return x.bi < toBig(int(y.f)))
         of BigInteger       || Quantity         :   (when GMP: return x.bi < y.q)
 
-        of Integer          || BigInteger       :   (when GMP: return toBig(x.i) < y.bi)
-        of Rational         || BigInteger       :   (when GMP: return x.rat < toRational(y.bi))
+        of Integer          || BigInteger       :   (when GMP: return toBig(x.i)      < y.bi)
+        of Rational         || BigInteger       :   (when GMP: return x.rat           < toRational(y.bi))
         of Floating         || BigInteger       :   (when GMP: return toBig(int(x.f)) < y.bi)
-        of Quantity         || BigInteger       :   (when GMP: return x.q < y.bi)
-        else:
-            if x.kind != y.kind: return false
-            case x.kind:
-                of Null: return false
-                of Logical: return false
-                of Complex:
-                    if x.z.re == y.z.re:
-                        return x.z.im < y.z.im
-                    else:
-                        return x.z.re < y.z.re
-                of Version: return x.version < y.version
-                of Type: return false
-                of Char: return $(x.c) < $(y.c)
-                of String,
-                    Word,
-                    Label,
-                    Literal,
-                    Attribute,
-                    AttributeLabel: return x.s < y.s
-                of Symbol: return false
-                of Inline,
-                    Block:
-                    return x.a.len < y.a.len
-                of Dictionary:
-                    return false
-                of Unit:
-                    return false
-                of Object:
-                    if (let compareMethod = x.proto.methods.getOrDefault("compare", nil); not compareMethod.isNil):
-                        return x.proto.doCompare(x, y) == -1
-                    else:
-                        return false
-                of Date:
-                    return x.eobj[] < y.eobj[]
-                else:
-                    return false
+        of Quantity         || BigInteger       :   (when GMP: return x.q             < y.bi)
+
+        of Null             || Null             : return false
+        of Logical          || Logical          : return false
+        of Complex          || Complex          :
+            if x.z.re == y.z.re:
+                return x.z.im < y.z.im
+            else:
+                return x.z.re < y.z.re
+        of Version          || Version          : return x.version < y.version
+        of Type             || Type             : return false
+        of Char             || Char             : return $(x.c) < $(y.c)
+        of String           || String,
+            Word            || Word,
+            Label           || Label,
+            Literal         || Literal,
+            Attribute       || Attribute,
+            AttributeLabel  || AttributeLabel   : return x.s < y.s
+        of Symbol           || Symbol           : return false
+        of Inline           || Inline,
+            Block           || Block            : return x.a.len < y.a.len
+        of Dictionary       || Dictionary       : return false
+        of Unit             || Unit             : return false
+        of Object           || Object:
+            if not x.proto.methods.getOrDefault("compare", nil).isNil:
+                return x.proto.doCompare(x, y) == -1
+            else:
+                return false
+        of Date             || Date             : return x.eobj[] < y.eobj[]
+        else                                    : return false
 
 proc `>`*(x: Value, y: Value): bool {.inline.}=
     if x.kind in {Integer, Floating, Rational} and y.kind in {Integer, Floating, Rational}:

--- a/src/vm/values/comparison.nim
+++ b/src/vm/values/comparison.nim
@@ -122,33 +122,32 @@ proc `==`*(x: Value, y: Value): bool =
             discard
 
     elif x.kind == Quantity or y.kind == Quantity:
-        if y.kind == Integer:
+        case pair
+        of Quantity || Integer:
             if y.iKind == NormalInteger:
                 return x.q == y.i
             else:
                 when not defined(NOGMP):
                     return x.q == y.bi
-        elif y.kind == Floating:
+        of Quantity || Floating:
             return x.q == y.f
-        elif y.kind == Rational:
+        of Quantity || Rational:
             return x.q == y.rat
-        elif y.kind == Quantity:
-            if x.kind == Integer:
+        of Integer || Quantity:
                 if x.iKind == NormalInteger:
                     return x.i == y.q
                 else:
                     when not defined(NOGMP):
                         return x.bi == y.q
-            elif x.kind == Floating:
+        of Floating || Quantity:
                 return x.f == y.q
-            elif x.kind == Rational:
+        of Rational || Quantity:
                 return x.rat == y.q
-            else:
+        of Quantity || Quantity:
                 return x.q == y.q
         else:
             return false
-    elif x.kind == Error and y.kind == ErrorKind:
-        return x.err.kind == y.errkind
+        
     elif x.kind == ErrorKind and y.kind == Error:
         return x.errkind == y.err.kind
     else:

--- a/src/vm/values/comparison.nim
+++ b/src/vm/values/comparison.nim
@@ -61,7 +61,10 @@ proc `==`*(x: ValueArray, y: ValueArray): bool {.inline, enforceNoRaises.} =
 #  labels: vm, values, enhancement, unit-test
 
 proc `==`*(x: Value, y: Value): bool =
-    if x.kind in {Integer, Floating, Rational} and y.kind in {Integer, Floating, Rational}:
+    
+    let numericKind = {Integer, Floating, Rational}
+
+    if x.kind in numericKind and y.kind in numericKind:
         if x.kind==Integer:
             if y.kind==Integer: 
                 if likely(x.iKind==NormalInteger and y.iKind==NormalInteger):

--- a/src/vm/values/comparison.nim
+++ b/src/vm/values/comparison.nim
@@ -267,118 +267,77 @@ proc `==`*(x: Value, y: Value): bool =
 #  labels: enhancement,values,open discussion,unit-test
 
 proc `<`*(x: Value, y: Value): bool {.inline.}=
-    if x.kind in {Integer, Floating, Rational} and y.kind in {Integer, Floating, Rational}:
-        if x.kind==Integer:
-            if y.kind==Integer: 
-                if likely(x.iKind==NormalInteger and y.iKind==NormalInteger):
-                    return x.i<y.i
-                elif x.iKind==NormalInteger and y.iKind==BigInteger:
-                    when defined(WEB):
-                        return big(x.i)<y.bi
-                    elif not defined(NOGMP):
-                        return x.i<y.bi
-                elif x.iKind==BigInteger and y.iKind==NormalInteger:
-                    when defined(WEB):
-                        return x.bi<big(y.i)
-                    elif not defined(NOGMP):
-                        return x.bi<y.i
-                else:
-                    when defined(WEB) or not defined(NOGMP):
-                        return x.bi<y.bi
-            elif y.kind==Rational:
-                return cmp(toRational(x.i), y.rat) < 0
-            else: 
-                if x.iKind==NormalInteger:
-                    return x.i<y.f
-                else:
-                    when defined(WEB):
-                        return x.bi<big(int(y.f))
-                    elif not defined(NOGMP):
-                        return (x.bi)<int(y.f)
-        elif x.kind==Rational:
-            if y.kind==Integer:
-                if likely(y.iKind==NormalInteger):
-                    return cmp(x.rat,toRational(y.i))<0
+    let pair = getValuePair()
+
+    case pair:
+        of Integer          || Integer          :   return x.i   < y.i
+        of Rational         || Rational         :   return x.rat < y.rat
+        of Floating         || Floating         :   return x.f   < y.f
+        of Quantity         || Quantity         :   return x.q   < y.q
+        
+        of Integer          || Floating         :   return float(x.i)      < y.f
+        of Integer          || Rational         :   return toRational(x.i) < y.rat
+        of Integer          || Quantity         :   return x.i             < y.q
+     
+        of Rational         || Integer          :   return x.rat < toRational(y.i)
+        of Rational         || Floating         :   return x.rat < toRational(y.f)
+        of Rational         || Quantity         :   return x.rat < y.q
+        
+        of Floating         || Integer          :   return x.f             < float(y.i)
+        of Floating         || Rational         :   return toRational(x.f) < y.rat
+        of Floating         || Quantity         :   return x.f             < y.q
+        
+        of Quantity         || Integer          :   return x.q < y.i
+        of Quantity         || Floating         :   return x.q < y.f
+        of Quantity         || Rational         :   return x.q < y.rat
+        
+        of BigInteger       || BigInteger       :   (when GMP: return x.bi < y.bi)
+        
+        of BigInteger       || Integer          :   (when GMP: return x.bi < toBig(y.i))
+        of BigInteger       || Rational         :   return false
+        of BigInteger       || Floating         :   (when GMP: return x.bi < toBig(int(y.f)))
+        of BigInteger       || Quantity         :   (when GMP: return x.bi < y.q)
+
+        of Integer          || BigInteger       :   (when GMP: return toBig(x.i) < y.bi)
+        of Rational         || BigInteger       :   (when GMP: return x.rat < toRational(y.bi))
+        of Floating         || BigInteger       :   (when GMP: return toBig(int(x.f)) < y.bi)
+        of Quantity         || BigInteger       :   (when GMP: return x.q < y.bi)
+        else:
+            if x.kind != y.kind: return false
+            case x.kind:
+                of Null: return false
+                of Logical: return false
+                of Complex:
+                    if x.z.re == y.z.re:
+                        return x.z.im < y.z.im
+                    else:
+                        return x.z.re < y.z.re
+                of Version: return x.version < y.version
+                of Type: return false
+                of Char: return $(x.c) < $(y.c)
+                of String,
+                    Word,
+                    Label,
+                    Literal,
+                    Attribute,
+                    AttributeLabel: return x.s < y.s
+                of Symbol: return false
+                of Inline,
+                    Block:
+                    return x.a.len < y.a.len
+                of Dictionary:
+                    return false
+                of Unit:
+                    return false
+                of Object:
+                    if (let compareMethod = x.proto.methods.getOrDefault("compare", nil); not compareMethod.isNil):
+                        return x.proto.doCompare(x, y) == -1
+                    else:
+                        return false
+                of Date:
+                    return x.eobj[] < y.eobj[]
                 else:
                     return false
-            elif y.kind==Rational:
-                return cmp(x.rat,y.rat)<0
-            else:
-                return cmp(x.rat,toRational(y.f))<0
-        else:
-            if y.kind==Integer: 
-                if y.iKind==NormalInteger:
-                    return x.f<y.i
-                else:
-                    when defined(WEB):
-                        return big(int(x.f))<y.bi
-                    elif not defined(NOGMP):
-                        return int(x.f)<y.bi      
-            elif y.kind==Rational:
-                return cmp(toRational(x.f), y.rat) < 0  
-            else: return x.f<y.f
-    elif x.kind == Quantity or y.kind == Quantity:
-        if y.kind == Integer:
-            if y.iKind == NormalInteger:
-                return x.q < y.i
-            else:
-                when not defined(NOGMP):
-                    return x.q < y.bi
-        elif y.kind == Floating:
-            return x.q < y.f
-        elif y.kind == Rational:
-            return x.q < y.rat
-        elif y.kind == Quantity:
-            if x.kind == Integer:
-                if x.iKind == NormalInteger:
-                    return x.i < y.q
-                else:
-                    when not defined(NOGMP):
-                        return x.bi < y.q
-            elif x.kind == Floating:
-                return x.f < y.q
-            elif x.kind == Rational:
-                return x.rat < y.q
-            else:
-                return x.q < y.q
-        else:
-            return false
-    else:
-        if x.kind != y.kind: return false
-        case x.kind:
-            of Null: return false
-            of Logical: return false
-            of Complex:
-                if x.z.re == y.z.re:
-                    return x.z.im < y.z.im
-                else:
-                    return x.z.re < y.z.re
-            of Version: return x.version < y.version
-            of Type: return false
-            of Char: return $(x.c) < $(y.c)
-            of String,
-               Word,
-               Label,
-               Literal,
-               Attribute,
-               AttributeLabel: return x.s < y.s
-            of Symbol: return false
-            of Inline,
-               Block:
-                return x.a.len < y.a.len
-            of Dictionary:
-                return false
-            of Unit:
-                return false
-            of Object:
-                if (let compareMethod = x.proto.methods.getOrDefault("compare", nil); not compareMethod.isNil):
-                    return x.proto.doCompare(x, y) == -1
-                else:
-                    return false
-            of Date:
-                return x.eobj[] < y.eobj[]
-            else:
-                return false
 
 proc `>`*(x: Value, y: Value): bool {.inline.}=
     if x.kind in {Integer, Floating, Rational} and y.kind in {Integer, Floating, Rational}:

--- a/src/vm/values/comparison.nim
+++ b/src/vm/values/comparison.nim
@@ -82,17 +82,19 @@ proc `==`*(x: Value, y: Value): bool =
         of Integer          || Integer          :   return x.i==y.i
         of Rational         || Rational         :   return x.rat==y.rat
         of Floating         || Floating         :   return x.f==y.f
-        of Integer          || Rational         :   return toRational(x.i)==y.rat
         of Quantity         || Quantity         :   return x.q==y.q
         
         of Integer          || Floating         :   return float(x.i)==y.f
+        of Integer          || Rational         :   return toRational(x.i)==y.rat
         of Integer          || Quantity         :   return x.i==y.q
      
         of Rational         || Integer          :   return x.rat==toRational(y.i)
         of Rational         || Floating         :   return x.rat==toRational(y.f)
+        of Rational         || Quantity         :   return x.rat==y.q
         
         of Floating         || Integer          :   return x.f==float(y.i)
         of Floating         || Rational         :   return toRational(x.f)==y.rat
+        of Floating         || Quantity         :   return x.f==y.q
         
         of Quantity         || Integer          :   return x.q==y.i
         of Quantity         || Floating         :   return x.q==y.f

--- a/src/vm/values/comparison.nim
+++ b/src/vm/values/comparison.nim
@@ -148,10 +148,18 @@ proc `==`*(x: Value, y: Value): bool =
         else:
             return false
         
-    elif x.kind == ErrorKind and y.kind == Error:
-        return x.errkind == y.err.kind
-    else:
-        if x.kind != y.kind: return false
+    elif x.kind in {Error, ErrorKind} and y.kind in {Error, ErrorKind}:
+        case pair
+        of Error || ErrorKind:
+            return x.err.kind == y.errkind
+        of ErrorKind || Error:
+            return x.errkind == y.err.kind
+        of Error || Error:
+            return x.err == y.err
+        of ErrorKind || ErrorKind:
+            return x.errkind == y.errkind
+        else:
+            return false
 
         case x.kind:
             of Null: return true

--- a/src/vm/values/comparison.nim
+++ b/src/vm/values/comparison.nim
@@ -120,15 +120,17 @@ proc `==`*(x: Value, y: Value): bool =
             of Error      || ErrorKind : return x.err.kind == y.errkind
             of ErrorKind  || Error     : return x.errkind  == y.err.kind
             else:
-                if x.kind != y.kind:
-                    return false
+                discard
+
+    if x.kind != y.kind:
+        return false
 
     case x.kind:
         of Error:   
             return x.err == y.err
         of ErrorKind:   
             return x.errkind == y.errkind
-        of Null:   
+        of Null:
             return true
         of Logical:   
             return x.b == y.b
@@ -316,14 +318,12 @@ proc `<`*(x: Value, y: Value): bool {.inline.}=
             of Floating   || BigInteger:   (when GMP: return toBig(int(x.f)) < y.bi)
             of Quantity   || BigInteger:   (when GMP: return x.q             < y.bi)
             else:
-                if x.kind != y.kind:
-                    return false
+                discard
+
+    if x.kind != y.kind:
+        return false
 
     case x.kind:
-        of Null: 
-            return false
-        of Logical: 
-            return false
         of Complex:
             if x.z.re == y.z.re:
                 return x.z.im < y.z.im
@@ -331,20 +331,12 @@ proc `<`*(x: Value, y: Value): bool {.inline.}=
                 return x.z.re < y.z.re
         of Version: 
             return x.version < y.version
-        of Type: 
-            return false
         of Char: 
             return $(x.c) < $(y.c)
         of String, Word, Label, Literal, Attribute, AttributeLabel: 
             return x.s < y.s
-        of Symbol: 
-            return false
         of Inline, Block: 
             return x.a.len < y.a.len
-        of Dictionary: 
-            return false
-        of Unit: 
-            return false
         of Object:
             if not x.proto.methods.getOrDefault("compare", nil).isNil:
                 return x.proto.doCompare(x, y) == -1
@@ -394,14 +386,12 @@ proc `>`*(x: Value, y: Value): bool {.inline.}=
             of Floating   || BigInteger:   (when GMP: return toBig(int(x.f)) > y.bi)
             of Quantity   || BigInteger:   (when GMP: return x.q             > y.bi)
             else:
-                if x.kind != y.kind:
-                    return false
+                discard
+
+    if x.kind != y.kind:
+        return false
 
     case x.kind:
-        of Null:   
-            return false
-        of Logical:   
-            return false
         of Complex:
             if x.z.re == y.z.re:
                 return x.z.im > y.z.im
@@ -409,20 +399,12 @@ proc `>`*(x: Value, y: Value): bool {.inline.}=
                 return x.z.re > y.z.re
         of Version:   
             return x.version > y.version
-        of Type:   
-            return false
         of Char:   
             return $(x.c) > $(y.c)
         of String, Word, Label, Literal, Attribute, AttributeLabel:   
             return x.s > y.s
-        of Symbol:   
-            return false
         of Inline, Block:   
             return x.a.len > y.a.len
-        of Dictionary:   
-            return false
-        of Unit:   
-            return false
         of Object:
             if not x.proto.methods.getOrDefault("compare", nil).isNil:
                 return x.proto.doCompare(x, y) == 1

--- a/src/vm/values/comparison.nim
+++ b/src/vm/values/comparison.nim
@@ -147,7 +147,7 @@ proc `==`*(x: Value, y: Value): bool =
                 return x.q == y.q
         else:
             return false
-        
+
     elif x.kind in {Error, ErrorKind} and y.kind in {Error, ErrorKind}:
         case pair
         of Error || ErrorKind:
@@ -160,82 +160,85 @@ proc `==`*(x: Value, y: Value): bool =
             return x.errkind == y.errkind
         else:
             return false
+    else:
+        if x.kind != y.kind: 
+            return false
 
-        case x.kind:
-            of Null: return true
-            of Logical: return x.b == y.b
-            of Complex: return x.z == y.z
-            of Version:
-                return x.version == y.version
-            of Type: return x.t == y.t
-            of Char: return x.c == y.c
-            of String,
-               Word,
-               Label,
-               Literal,
-               Attribute,
-               AttributeLabel: return x.s == y.s
-            of Path,
-               PathLabel,
-               PathLiteral: return x.p == y.p
-            of Symbol: return x.m == y.m
-            of Regex: return x.rx == y.rx
-            of Error: return x.err == y.err
-            of ErrorKind: return x.errkind == y.errkind
-            of Binary: return x.n == y.n
-            of Bytecode: return x.trans[] == y.trans[]
-            of Inline,
-               Block:
+        case pair
+        of Null || Null: return true
+        of Logical || Logical: return x.b == y.b
+        of Complex || Complex: return x.z == y.z
+        of Version || Version:
+            return x.version == y.version
+        of Type || Type: return x.t == y.t
+        of Char || Char: return x.c == y.c
+        of String || String,
+            Word || Word,
+            Label || Label,
+            Literal || Literal,
+            Attribute || Attribute,
+            AttributeLabel || AttributeLabel: return x.s == y.s
+        of Path || Path,
+            PathLabel || PathLabel,
+            PathLiteral || PathLiteral: return x.p == y.p
+        of Symbol || Symbol: return x.m == y.m
+        of Regex || Regex: return x.rx == y.rx
+        of Error || Error: return x.err == y.err
+        of ErrorKind || ErrorKind: return x.errkind == y.errkind
+        of Binary || Binary: return x.n == y.n
+        of Bytecode || Bytecode: return x.trans[] == y.trans[]
+        of Inline || Inline,
+            Block || Block:
 
-                if x.a.len != y.a.len: return false
+            if x.a.len != y.a.len: return false
 
-                for i,child in x.a:
-                    if not (child==y.a[i]): return false
+            for i,child in x.a:
+                if not (child==y.a[i]): return false
 
-                return true
+            return true
 
-            of Range:
-                return x.rng == y.rng
+        of Range || Range:
+            return x.rng == y.rng
 
-            of Dictionary:
-                if x.d.len != y.d.len: return false
+        of Dictionary || Dictionary:
+            if x.d.len != y.d.len: return false
 
-                for k,v in pairs(x.d):
-                    if not y.d.hasKey(k): return false
-                    if not (v==y.d[k]): return false
+            for k,v in pairs(x.d):
+                if not y.d.hasKey(k): return false
+                if not (v==y.d[k]): return false
 
-                return true
-            of Unit:
-                return x.u == y.u
-            of Object:
-                if (let compareMethod = x.proto.methods.getOrDefault("compare", nil); not compareMethod.isNil):
-                    return x.proto.doCompare(x,y) == 0
-                else:
-                    if x.o.len != y.o.len: return false
-
-                    for k,v in pairs(x.o):
-                        if not y.o.hasKey(k): return false
-                        if not (v==y.o[k]): return false
-
-                    return true
-            of Store:
-                return x.sto.path == y.sto.path and x.sto.kind == y.sto.kind
-            of Color:
-                return x.l == y.l
-            of Function:
-                if x.fnKind==UserFunction:
-                    return x.params == y.params and x.main == y.main and x.exports == y.exports
-                else:
-                    return x.action == y.action
-            of Database:
-                if x.dbKind != y.dbKind: return false
-                when not defined(NOSQLITE):
-                    if x.dbKind==SqliteDatabase: return cast[uint](x.sqlitedb) == cast[uint](y.sqlitedb)
-                    #elif x.dbKind==MysqlDatabase: return cast[uint](x.mysqldb) == cast[uint](y.mysqldb)
-            of Date:
-                return x.eobj[] == y.eobj[]
+            return true
+        of Unit || Unit:
+            return x.u == y.u
+        of Object || Object:
+            if (let compareMethod = x.proto.methods.getOrDefault("compare", nil); not compareMethod.isNil):
+                return x.proto.doCompare(x,y) == 0
             else:
-                return false
+                if x.o.len != y.o.len: return false
+
+                for k,v in pairs(x.o):
+                    if not y.o.hasKey(k): return false
+                    if not (v==y.o[k]): return false
+
+                return true
+        of Store || Store:
+            return x.sto.path == y.sto.path and x.sto.kind == y.sto.kind
+        of Color || Color:
+            return x.l == y.l
+        of Function || Function:
+            if x.fnKind==UserFunction:
+                return x.params == y.params and x.main == y.main and x.exports == y.exports
+            else:
+                return x.action == y.action
+        of Database || Database:
+            if x.dbKind != y.dbKind: return false
+            when not defined(NOSQLITE):
+                if x.dbKind==SqliteDatabase: return cast[uint](x.sqlitedb) == cast[uint](y.sqlitedb)
+                #elif x.dbKind==MysqlDatabase: return cast[uint](x.mysqldb) == cast[uint](y.mysqldb)
+        of Date || Date:
+            return x.eobj[] == y.eobj[]
+        else:
+            return false
 
 # TODO(VM/values/comparison) how should we handle Dictionary values?
 #  right now, both `<` and `>` simply return false

--- a/src/vm/values/comparison.nim
+++ b/src/vm/values/comparison.nim
@@ -79,50 +79,50 @@ proc `==`*(x: Value, y: Value): bool =
     
     let pair = getValuePair()
     case pair:
-        of Integer          || Integer          :   return x.i==y.i
-        of Rational         || Rational         :   return x.rat==y.rat
-        of Floating         || Floating         :   return x.f==y.f
-        of Quantity         || Quantity         :   return x.q==y.q
+        of Integer          || Integer          :   return x.i   == y.i
+        of Rational         || Rational         :   return x.rat == y.rat
+        of Floating         || Floating         :   return x.f   == y.f
+        of Quantity         || Quantity         :   return x.q   == y.q
         
-        of Integer          || Floating         :   return float(x.i)==y.f
-        of Integer          || Rational         :   return toRational(x.i)==y.rat
-        of Integer          || Quantity         :   return x.i==y.q
+        of Integer          || Floating         :   return float(x.i)      == y.f
+        of Integer          || Rational         :   return toRational(x.i) == y.rat
+        of Integer          || Quantity         :   return x.i             == y.q
      
-        of Rational         || Integer          :   return x.rat==toRational(y.i)
-        of Rational         || Floating         :   return x.rat==toRational(y.f)
-        of Rational         || Quantity         :   return x.rat==y.q
+        of Rational         || Integer          :   return x.rat == toRational(y.i)
+        of Rational         || Floating         :   return x.rat == toRational(y.f)
+        of Rational         || Quantity         :   return x.rat == y.q
         
-        of Floating         || Integer          :   return x.f==float(y.i)
-        of Floating         || Rational         :   return toRational(x.f)==y.rat
-        of Floating         || Quantity         :   return x.f==y.q
+        of Floating         || Integer          :   return x.f             == float(y.i)
+        of Floating         || Rational         :   return toRational(x.f) == y.rat
+        of Floating         || Quantity         :   return x.f             == y.q
         
-        of Quantity         || Integer          :   return x.q==y.i
-        of Quantity         || Floating         :   return x.q==y.f
-        of Quantity         || Rational         :   return x.q==y.rat
+        of Quantity         || Integer          :   return x.q == y.i
+        of Quantity         || Floating         :   return x.q == y.f
+        of Quantity         || Rational         :   return x.q == y.rat
         
-        of BigInteger       || BigInteger       :   (when GMP: return x.bi==y.bi)
+        of BigInteger       || BigInteger       :   (when GMP: return x.bi == y.bi)
         
-        of BigInteger       || Integer          :   (when GMP: return x.bi==toBig(y.i))
+        of BigInteger       || Integer          :   (when GMP: return x.bi == toBig(y.i))
         of BigInteger       || Rational         :   return false
-        of BigInteger       || Floating         :   (when GMP: return x.bi==toBig(int(y.f)))
-        of BigInteger       || Quantity         :   (when GMP: return x.bi==y.q)
+        of BigInteger       || Floating         :   (when GMP: return x.bi == toBig(int(y.f)))
+        of BigInteger       || Quantity         :   (when GMP: return x.bi == y.q)
 
-        of Integer          || BigInteger       :   (when GMP: return toBig(x.i)==y.bi)
-        of Rational         || BigInteger       :   (when GMP: return x.rat==toRational(y.bi))
-        of Floating         || BigInteger       :   (when GMP: return toBig(int(x.f))==y.bi)
-        of Quantity         || BigInteger       :   (when GMP: return x.q==y.bi)
+        of Integer          || BigInteger       :   (when GMP: return toBig(x.i) == y.bi)
+        of Rational         || BigInteger       :   (when GMP: return x.rat == toRational(y.bi))
+        of Floating         || BigInteger       :   (when GMP: return toBig(int(x.f)) == y.bi)
+        of Quantity         || BigInteger       :   (when GMP: return x.q == y.bi)
 
         of Error            || ErrorKind        :   return x.err.kind == y.errkind
-        of ErrorKind        || Error            :   return x.errkind == y.err.kind
-        of Error            || Error            :   return x.err == y.err
-        of ErrorKind        || ErrorKind        :   return x.errkind == y.errkind
+        of ErrorKind        || Error            :   return x.errkind  == y.err.kind
+        of Error            || Error            :   return x.err      == y.err
+        of ErrorKind        || ErrorKind        :   return x.errkind  == y.errkind
     
         of Null             || Null             :   return true
-        of Logical          || Logical          :   return x.b == y.b
-        of Complex          || Complex          :   return x.z == y.z
+        of Logical          || Logical          :   return x.b       == y.b
+        of Complex          || Complex          :   return x.z       == y.z
         of Version          || Version          :   return x.version == y.version
-        of Type             || Type             :   return x.t == y.t
-        of Char             || Char             :   return x.c == y.c
+        of Type             || Type             :   return x.t       == y.t
+        of Char             || Char             :   return x.c       == y.c
         of String           || String,
             Word            || Word,
             Label           || Label,
@@ -131,18 +131,18 @@ proc `==`*(x: Value, y: Value): bool =
             AttributeLabel  || AttributeLabel   :   return x.s == y.s
         of Path             || Path,
             PathLabel       || PathLabel,
-            PathLiteral     || PathLiteral      :   return x.p == y.p
-        of Symbol           || Symbol           :   return x.m == y.m
-        of Regex            || Regex            :   return x.rx == y.rx
-        of Binary           || Binary           :   return x.n == y.n
+            PathLiteral     || PathLiteral      :   return x.p       == y.p
+        of Symbol           || Symbol           :   return x.m       == y.m
+        of Regex            || Regex            :   return x.rx      == y.rx
+        of Binary           || Binary           :   return x.n       == y.n
         of Bytecode         || Bytecode         :   return x.trans[] == y.trans[]
         of Inline           || Inline,
             Block           || Block            :
             if x.a.len != y.a.len: 
                 return false
 
-            for i,child in x.a:
-                if not (child==y.a[i]): 
+            for i, child in x.a:
+                if child != y.a[i]: 
                     return false
 
             return true
@@ -152,24 +152,27 @@ proc `==`*(x: Value, y: Value): bool =
             if x.d.len != y.d.len: 
                 return false
 
-            for k,v in pairs(x.d):
+            for k, v in pairs(x.d):
                 if not y.d.hasKey(k): 
                     return false
-                if not (v==y.d[k]): 
+                if v != y.d[k]: 
                     return false
 
             return true
 
         of Unit             || Unit             :   return x.u == y.u
         of Object           || Object           :
-            if (let compareMethod = x.proto.methods.getOrDefault("compare", nil); not compareMethod.isNil):
+            if not x.proto.methods.getOrDefault("compare", nil).isNil:
                 return x.proto.doCompare(x,y) == 0
             else:
-                if x.o.len != y.o.len: return false
+                if x.o.len != y.o.len: 
+                    return false
 
                 for k,v in pairs(x.o):
-                    if not y.o.hasKey(k): return false
-                    if not (v==y.o[k]): return false
+                    if not y.o.hasKey(k): 
+                        return false
+                    if not (v == y.o[k]): 
+                        return false
 
                 return true
 
@@ -181,9 +184,11 @@ proc `==`*(x: Value, y: Value): bool =
             else:
                 return x.action == y.action
         of Database         || Database         :
-            if x.dbKind != y.dbKind: return false
+            if x.dbKind != y.dbKind: 
+                return false
             when not defined(NOSQLITE):
-                if x.dbKind==SqliteDatabase: return cast[uint](x.sqlitedb) == cast[uint](y.sqlitedb)
+                if x.dbKind==SqliteDatabase: 
+                    return cast[uint](x.sqlitedb) == cast[uint](y.sqlitedb)
                 #elif x.dbKind==MysqlDatabase: return cast[uint](x.mysqldb) == cast[uint](y.mysqldb)
         of Date             || Date             :   return x.eobj[] == y.eobj[]
         else                                    :   return false


### PR DESCRIPTION
# Description

Benchmarks and tries to replace the ugly `case`/`of` by our newer, faster? and more readable approach `getValuePair`.

- Fixes #1149

## Type of change

- [x] Code cleanup
- [x] Enhancement (implementation update, or general performance enhancements)