### PR TITLE
[System\config] Add support for local config

### DIFF
--- a/src/library/System.nim
+++ b/src/library/System.nim
@@ -118,12 +118,13 @@ proc defineLibrary*() =
             alias       = unaliased, 
             op          = opNop,
             rule        = PrefixPrecedence,
-            description = "get global configuration",
+            description = "get local or global configuration",
             args        = NoArgs,
             attrs       = NoAttrs,
             returns     = {Store},
             example     = """
-                ; `config` returns a `:store` from `~/.arturo/stores/config.art`
+                ; `config` searches for `config.art` into your current directory. 
+                ; if not found, it returns from `~/.arturo/stores/config.art`
 
                 config
                 ; => []

--- a/src/library/System.nim
+++ b/src/library/System.nim
@@ -114,8 +114,6 @@ proc defineLibrary*() =
 
     when not defined(WEB):
 
-        # TODO(System\config) add documentation example
-        #  labels: library, documentation, easy
         builtin "config",
             alias       = unaliased, 
             op          = opNop,

--- a/src/library/System.nim
+++ b/src/library/System.nim
@@ -125,6 +125,23 @@ proc defineLibrary*() =
             attrs       = NoAttrs,
             returns     = {Store},
             example     = """
+                ; `config` returns a `:store` from `~/.arturo/stores/config.art`
+
+                config
+                ; => []
+                ; `config.art` is empty at first, but we can change this manually
+
+                write.append path\home ++ normalize ".arturo/stores/config.art" 
+                             "language: {Arturo}"
+                config
+                ; => []
+                
+                ; this stills empty, but now try to relaunch Arturo:
+                exit
+                ......................
+                config
+                ; => [language:Arturo]
+
             """:
                 push(Config)
 

--- a/src/vm/vm.nim
+++ b/src/vm/vm.nim
@@ -141,17 +141,33 @@ template initialize(args: seq[string], filename: string, isFile:bool, scriptData
 
     when not defined(WEB):
         # configuration
-        Config = newStore(
-            initStore(
-                "config",
-                doLoad=false,
-                forceExtension=true,
-                createIfNotExists=true,
-                global=true,
-                autosave=true,
-                kind=NativeStore
+
+        let currentDir = os.getCurrentDir()
+
+        if os.fileExists(currentDir/"config.art"):
+            Config = newStore(
+                initStore(
+                    currentDir/"config.art",
+                    doLoad=false,
+                    forceExtension=true,
+                    createIfNotExists=false,
+                    global=false,
+                    autosave=true,
+                    kind=NativeStore
+                )
             )
-        )
+        else:
+            Config = newStore(
+                initStore(
+                    "config",
+                    doLoad=false,
+                    forceExtension=true,
+                    createIfNotExists=true,
+                    global=true,
+                    autosave=true,
+                    kind=NativeStore
+                )
+            )
 
     when not defined(WEB):
         # paths


### PR DESCRIPTION
# Description

Adds support for local config and adds proper documentation.

Basically, it checks first for `config.art` on the current directory, 
if there is nothing it picks up the global one from `~/.arturo/stores/config.art`.

- Fixes #1216

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (implementation update, or general performance enhancements)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (documentation-related additions)