### PR TITLE
[Core\var]: add support for `:word`

### DIFF
--- a/src/library/Core.nim
+++ b/src/library/Core.nim
@@ -1105,7 +1105,7 @@ proc defineLibrary*() =
         rule        = PrefixPrecedence,
         description = "get symbol value by given name",
         args        = {
-            "symbol"    : {String,Literal,PathLiteral}
+            "symbol"    : {String,Literal,PathLiteral,Word}
         },
         attrs       = NoAttrs,
         returns     = {Any},
@@ -1120,7 +1120,7 @@ proc defineLibrary*() =
             print g 10              ; 12
         """:
             #=======================================================
-            if xKind in {String,Literal}:
+            if xKind in {String,Literal,Word}:
                 push(FetchSym(x.s))
             else:
                 push(FetchPathSym(x.p))


### PR DESCRIPTION
# Description

A short demonstration:
![image](https://github.com/arturo-lang/arturo/assets/78623871/215d74df-ba33-41e9-afd4-422e725ac9d7)


- Fixes #1325

## Type of change

- [x] New feature (non-breaking change which adds functionality)