### PR TITLE
[vm\globals] ultra-experimental refactoring features... Enhancing control-flow 

### DIFF
--- a/src/vm/globals.nim
+++ b/src/vm/globals.nim
@@ -122,11 +122,11 @@ proc FetchSym*(s: string, unsafe: static bool = false): Value {.inline.} =
     ## Checks if a symbol name exists in the symbol table
     ## - if it doesn't, raise a SymbolNotFound error
     ## - otherwise, return its value
-    when not unsafe:
+    when unsafe:
+        Syms[s]
+    else:
         if (result = Syms.getOrDefault(s, nil); unlikely(result.isNil)):
             RuntimeError_SymbolNotFound(s, suggestAlternative(s))
-    else:
-        Syms[s]
 
 proc FetchPathSym*(pl: ValueArray): Value =
     ## Gets a the `.p` field of a PathLiteral value

--- a/src/vm/globals.nim
+++ b/src/vm/globals.nim
@@ -58,6 +58,10 @@ var
 
 type FunctionFlag[T: static bool] = bool
 
+template `:=`(a, b: untyped): untyped {.dirty.} =
+    let a = b
+    a
+
 func suggestAlternative(s: string, reference: SymTable | ValueDict = Syms): seq[string] {.inline.} =
     var levs = initOrderedTable[string,float]()
 

--- a/src/vm/globals.nim
+++ b/src/vm/globals.nim
@@ -56,6 +56,8 @@ var
 # Helpers
 #=======================================
 
+type FunctionFlag[T: static bool] = bool
+
 func suggestAlternative(s: string, reference: SymTable | ValueDict = Syms): seq[string] {.inline.} =
     var levs = initOrderedTable[string,float]()
 

--- a/src/vm/globals.nim
+++ b/src/vm/globals.nim
@@ -125,7 +125,7 @@ proc FetchSym*(s: string, unsafe: static bool = false): Value {.inline.} =
     when unsafe:
         Syms[s]
     else:
-        if (result = Syms.getOrDefault(s, nil); unlikely(result.isNil)):
+        if unlikely (result := Syms.getOrDefault(s, nil)).isNil:
             RuntimeError_SymbolNotFound(s, suggestAlternative(s))
 
 proc FetchPathSym*(pl: ValueArray): Value =

--- a/src/vm/globals.nim
+++ b/src/vm/globals.nim
@@ -252,11 +252,11 @@ template retrieveConfig*(globalKey: string, attrKey: string): untyped =
     var config {.inject.}: ValueDict
     var configFound = false
 
-    if (let globalConfig = Config.sto.getStoreKey(globalKey, unsafe=true); not globalConfig.isNil):
+    if not (globalConfig := Config.sto.getStoreKey(globalKey, unsafe=true)).isNil:
         configFound = true
         config = globalConfig.d
     
-    if (let attrConfig = getAttr(attrKey); attrConfig != VNULL):
+    if (attrConfig := getAttr(attrKey)) != VNULL:
         configFound = true
         config = attrConfig.d
 

--- a/src/vm/globals.nim
+++ b/src/vm/globals.nim
@@ -190,17 +190,18 @@ template SetSym*(s: string, v: Value, safe, forceReadOnly: FunctionFlag[true]): 
     ## going ahead and just assign it (pointer copy!)
     Syms[s] = copyValue(v)
 
-
-template SetDictSym*(s: string, v: Value, safe: static bool = false): untyped =
+template SetDictSym*(s: string, v: Value): untyped =
     ## Sets symbol to topmost Dictionary symbol table
-    when safe:
-        # When doing it safely, also check if the value to be assigned is a read-only value
-        # - if it is - we have to copy it first
-        # - otherwise, go ahead and just assign it (pointer copy!)
-        if v.readonly:
-            DictSyms[^1][s] = copyValue(v)
-        else:
-            DictSyms[^1][s] = v
+    DictSyms[^1][s] = v
+
+template SetDictSym*(s: string, v: Value, safe: FunctionFlag[true]): untyped =
+    ## Sets symbol to topmost Dictionary symbol table
+    ## 
+    ## When doing it safely, also check if the value to be assigned is a read-only value
+    ## - if it is - we have to copy it first
+    ## - otherwise, go ahead and just assign it (pointer copy!)
+    if v.readonly:
+        DictSyms[^1][s] = copyValue(v)
     else:
         DictSyms[^1][s] = v
 

--- a/src/vm/globals.nim
+++ b/src/vm/globals.nim
@@ -168,21 +168,28 @@ template GetSym*(s: string): untyped =
     ## so, we have to make sure we know it exists beforehand
     Syms[s]
 
-template SetSym*(s: string, v: Value, safe: static bool = false, forceReadOnly: static bool = false): untyped =
+template SetSym*(s: string, v: Value): untyped =
     ## Sets symbol to given value in the symbol table
-    when safe:
-        # When doing it safely, also check if the value to be assigned is a read-only value
-        # - if it is - we have to copy it first
-        # - otherwise, go ahead and just assign it (pointer copy!)
-        when forceReadOnly:
-            Syms[s] = copyValue(v)
-        else:
-            if v.readonly:
-                Syms[s] = copyValue(v)
-            else:
-                Syms[s] = v
+    Syms[s] = v
+
+template SetSym*(s: string, v: Value, safe: FunctionFlag[true]): untyped =
+    ## Sets symbol to given value in the symbol table
+    ## 
+    ## Also check if the value to be assigned is a read-only value
+    ## - if it is - we have to copy it first
+    ## - otherwise, go ahead and just assign it (pointer copy!)
+    if v.readonly:
+        Syms[s] = copyValue(v)
     else:
         Syms[s] = v
+        
+template SetSym*(s: string, v: Value, safe, forceReadOnly: FunctionFlag[true]): untyped =
+    ## Sets symbol to given value in the symbol table
+    ## 
+    ## When doing it safely forcing a read-only value.
+    ## going ahead and just assign it (pointer copy!)
+    Syms[s] = copyValue(v)
+
 
 template SetDictSym*(s: string, v: Value, safe: static bool = false): untyped =
     ## Sets symbol to topmost Dictionary symbol table

--- a/src/vm/globals.nim
+++ b/src/vm/globals.nim
@@ -118,15 +118,16 @@ template SymExists*(s: string): untyped =
     ## Checks if a symbol name exists in the symbol table
     Syms.hasKey(s)
 
-proc FetchSym*(s: string, unsafe: static bool = false): Value {.inline.} =
+proc FetchSym*(s: string): Value {.inline.} =
+    ## Fetches a symbol in the symbol table
+    if unlikely (result := Syms.getOrDefault(s, nil)).isNil:
+        RuntimeError_SymbolNotFound(s, suggestAlternative(s))
+
+proc FetchSym*(s: string, unsafe: FunctionFlag[true]): Value {.inline.} =
     ## Checks if a symbol name exists in the symbol table
     ## - if it doesn't, raise a SymbolNotFound error
     ## - otherwise, return its value
-    when unsafe:
-        Syms[s]
-    else:
-        if unlikely (result := Syms.getOrDefault(s, nil)).isNil:
-            RuntimeError_SymbolNotFound(s, suggestAlternative(s))
+    Syms[s]
 
 proc FetchPathSym*(pl: ValueArray): Value =
     ## Gets a the `.p` field of a PathLiteral value


### PR DESCRIPTION
# Description

I made this PR just as a ultra-experimental and drafty way of try new features for refactoring.

In this case, I removed some control-flow by using polimorphism with `FunctionFlag`. Something imitating [the Arturo's `:attribute`s][attrs] for procedures. Thanks @beef331 for your help with that.
And also, removed the code repetition when declaring variables inside an `if` statement, by copying [the Walrus Operator `:=` from Python (Formally, "Assignment Expression")][walrus].

[attrs]: https://arturo-lang.io/documentation/language/#attributes
[walrus]: https://peps.python.org/pep-0572/

## Type of change

- [x] Code cleanup
- [x] Enhancement (implementation update, or general performance enhancements)