### PR TITLE
[System\path]: remove TODO and add documentation usage

### DIFF
--- a/src/library/System.nim
+++ b/src/library/System.nim
@@ -304,11 +304,6 @@ proc defineLibrary*() =
             else:
                 ProgramError_panic(x.s.replace("\n",";"), code)
 
-    # TODO(Paths\path) shouldn't be considered a constant
-    #  let's say constants are exactly that: constants.
-    #  if the exact same "constant" returns different results based on
-    #  the system it's running on, then it's not a constant.
-    #  labels: library, enhancement
     builtin "path",
         alias       = unaliased, 
         op          = opNop,

--- a/src/library/System.nim
+++ b/src/library/System.nim
@@ -313,6 +313,8 @@ proc defineLibrary*() =
         attrs       = NoAttrs,
         returns     = {Dictionary},
         example     = """
+        path
+        ; => [current:C:\Users\me\my-proj home:C:\Users\me\ temp:C:\Users\me\AppData\Local\Temp\
         """:
             #=======================================================
             push(newDictionary(getPathInfo()))


### PR DESCRIPTION
# Description

This issue was alread solved, but never closed. And the TODO was never removed.

Beyhond, I noticed this function was missing proper example of usage, so I added it.

Fixes # (issue/s)

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (documentation-related additions)