### PR TITLE
Fix AST handling of method calls

### DIFF
--- a/src/vm/ast.nim
+++ b/src/vm/ast.nim
@@ -967,7 +967,7 @@ proc generateAst*(parsed: Value, asDictionary=false, asFunction=false, reuseArit
     var res = newRootNode()
 
     PipeParent = nil
-    CanStore = false
+    CanStore = true
 
     when not reuseArities:
         TmpArities = collect:

--- a/src/vm/ast.nim
+++ b/src/vm/ast.nim
@@ -107,6 +107,7 @@ var
     ArrowBlock : seq[ValueArray]
 
     PipeParent : Node
+    CanStore   : bool
 
 #=======================================
 # Constants
@@ -588,6 +589,7 @@ proc processBlock*(
                 var methodInvocation: Node
                 var ar: int8
                 var limitArity: int8
+                CanStore = false
                 if actualMethod.kind == Method:
                     ar = actualMethod.marity
                     limitArity = 2
@@ -961,10 +963,11 @@ proc dumpNode*(node: Node, level = 0, single: static bool = false, showNewlines:
 # Main
 #=======================================
 
-proc generateAst*(parsed: Value, asDictionary=false, asFunction=false, reuseArities: static bool=false): Node =
-    result = newRootNode()
+proc generateAst*(parsed: Value, asDictionary=false, asFunction=false, reuseArities: static bool=false): (Node, bool) =
+    var res = newRootNode()
 
     PipeParent = nil
+    CanStore = false
 
     when not reuseArities:
         TmpArities = collect:
@@ -972,6 +975,7 @@ proc generateAst*(parsed: Value, asDictionary=false, asFunction=false, reuseArit
                 if v.kind == Function:
                     {k: v.arity}
 
-    discard result.processBlock(parsed, asDictionary=asDictionary, asFunction=asFunction)
+    discard res.processBlock(parsed, asDictionary=asDictionary, asFunction=asFunction)
+    return (res, CanStore)
 
     #echo dumpNode(result)

--- a/src/vm/eval.nim
+++ b/src/vm/eval.nim
@@ -580,7 +580,7 @@ proc doEvalAndCheckSafety*(root: Value, isDictionary=false, isFunctionBlock=fals
     var consts: ValueArray
     var it: VBinary
 
-    let (astNode, canStore) = generateAst(root, asDictionary=isDictionary, asFunction=isFunctionBlock)
+    let (astNode, canStore {.used.})  = generateAst(root, asDictionary=isDictionary, asFunction=isFunctionBlock)
     evaluateBlock(astNode, consts, it, isDictionary=isDictionary, omitNewlines=omitNewlines)
     it.add(byte(opEnd))
 

--- a/src/vm/eval.nim
+++ b/src/vm/eval.nim
@@ -589,7 +589,7 @@ proc doEval*(root: Value, isDictionary=false, isFunctionBlock=false, omitNewline
     #dump(newBytecode(result))
 
     when useStored:
-        if vhash != -1 and canStore:
+        if canStore and vhash != -1:
             StoredTranslations[vhash] = result
 
 template evalOrGet*(item: Value, isFunction=false): untyped =

--- a/src/vm/eval.nim
+++ b/src/vm/eval.nim
@@ -294,11 +294,11 @@ template optimizeConditional(
             canWeOptimize = right.kind == ConstantValue and right.value.kind == Block
 
     if canWeOptimize:
-        let rightNode = generateAst(right.value, reuseArities=true)
+        let (rightNode,_) = generateAst(right.value, reuseArities=true)
 
         when withLoop:
             var leftIt: VBinary
-            let leftNode = generateAst(left.value, reuseArities=true)
+            let (leftNode,_) = generateAst(left.value, reuseArities=true)
 
         let stillProceed =
             when withLoop:
@@ -323,7 +323,8 @@ template optimizeConditional(
             when withPotentialElse:
                 # separately ast+evaluate else child block     
                 var elseIt: VBinary
-                evaluateBlock(generateAst(elseChild.value, reuseArities=true), consts, elseIt)
+                let (elseAstNode,_) = generateAst(elseChild.value, reuseArities=true)
+                evaluateBlock(elseAstNode, consts, elseIt)
 
             # get operand & added to the instructions
             let (newOp, replaceOp) = 
@@ -579,7 +580,8 @@ proc doEval*(root: Value, isDictionary=false, isFunctionBlock=false, omitNewline
     var consts: ValueArray
     var it: VBinary
 
-    evaluateBlock(generateAst(root, asDictionary=isDictionary, asFunction=isFunctionBlock), consts, it, isDictionary=isDictionary, omitNewlines=omitNewlines)
+    let (astNode, canStore) = generateAst(root, asDictionary=isDictionary, asFunction=isFunctionBlock)
+    evaluateBlock(astNode, consts, it, isDictionary=isDictionary, omitNewlines=omitNewlines)
     it.add(byte(opEnd))
 
     result = Translation(constants: consts, instructions: it)
@@ -587,7 +589,7 @@ proc doEval*(root: Value, isDictionary=false, isFunctionBlock=false, omitNewline
     #dump(newBytecode(result))
 
     when useStored:
-        if vhash != -1:
+        if vhash != -1 and canStore:
             StoredTranslations[vhash] = result
 
 template evalOrGet*(item: Value, isFunction=false): untyped =

--- a/src/vm/eval.nim
+++ b/src/vm/eval.nim
@@ -595,7 +595,7 @@ proc doEvalAndCheckSafety*(root: Value, isDictionary=false, isFunctionBlock=fals
         return (res, false)
 
 proc doEval*(root: Value, isDictionary=false, isFunctionBlock=false, omitNewlines=false, useStored: static bool = true): Translation {.inline.} =
-    (result, _) = doEvalAndCheckSafety(root, isDictionary, isFunctionBlock, omitNewlines, useStored)
+    return doEvalAndCheckSafety(root, isDictionary, isFunctionBlock, omitNewlines, useStored)[0]
 
 template evalOrGet*(item: Value, isFunction=false): untyped =
     if item.kind==Bytecode: item.trans

--- a/src/vm/eval.nim
+++ b/src/vm/eval.nim
@@ -575,7 +575,7 @@ proc doEvalAndCheckSafety*(root: Value, isDictionary=false, isFunctionBlock=fals
         if not root.dynamic:
             vhash = hash(root)
             if (let storedTranslation = StoredTranslations.getOrDefault(vhash, nil); not storedTranslation.isNil):
-                return storedTranslation
+                return (storedTranslation, true)
 
     var consts: ValueArray
     var it: VBinary
@@ -589,7 +589,7 @@ proc doEvalAndCheckSafety*(root: Value, isDictionary=false, isFunctionBlock=fals
     #dump(newBytecode(result))
     when useStored:
         if canStore and (vhash != -1):
-            StoredTranslations[vhash] = result
+            StoredTranslations[vhash] = res
         return (res, canStore)
     else:
         return (res, false)

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -384,11 +384,14 @@ proc execFunction*(fun: Value, fid: Hash) =
         # pop argument and set it
         SetSym(arg, stack.pop())
 
-    if fun.bcode.isNil:
-        fun.bcode = newBytecode(doEval(fun.main, isFunctionBlock=true))
-
     try:
-        ExecLoop(fun.bcode().trans.constants, fun.bcode().trans.instructions)
+        if not fun.bcode.isNil:
+            ExecLoop(fun.bcode().trans.constants, fun.bcode().trans.instructions)
+        else:
+            let (trans, storable) = doEvalAndCheckSafety(fun.main, isFunctionBlock)
+            if storable:
+                fun.bcode = newBytecode(trans)
+            ExecLoop(trans.constants, trans.instructions)
 
     except ReturnTriggered:
         discard
@@ -448,11 +451,14 @@ proc execFunctionInline*(fun: Value, fid: Hash) =
         # pop argument and set it
         SetSym(arg, stack.pop())
 
-    if fun.bcode.isNil:
-        fun.bcode = newBytecode(doEval(fun.main, isFunctionBlock=true))
-
     try:
-        ExecLoop(fun.bcode().trans.constants, fun.bcode().trans.instructions)
+        if not fun.bcode.isNil:
+            ExecLoop(fun.bcode().trans.constants, fun.bcode().trans.instructions)
+        else:
+            let (trans, storable) = doEvalAndCheckSafety(fun.main, isFunctionBlock)
+            if storable:
+                fun.bcode = newBytecode(trans)
+            ExecLoop(trans.constants, trans.instructions)
 
     except ReturnTriggered:
         discard
@@ -489,11 +495,14 @@ proc execMethod*(meth: Value, fid: Hash) =
         # pop argument and set it
         SetSym(arg, stack.pop())
 
-    if meth.mbcode.isNil:
-        meth.mbcode = newBytecode(doEval(meth.mmain, isFunctionBlock=true))
-
     try:
-        ExecLoop(meth.mbcode().trans.constants, meth.mbcode().trans.instructions)
+        if not meth.mbcode.isNil:
+            ExecLoop(meth.mbcode().trans.constants, fun.mbcode().trans.instructions)
+        else:
+            let (trans, storable) = doEvalAndCheckSafety(meth.mmain, isFunctionBlock)
+            if storable:
+                meth.mbcode = newBytecode(trans)
+            ExecLoop(trans.constants, trans.instructions)
 
     except ReturnTriggered:
         discard

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -497,7 +497,7 @@ proc execMethod*(meth: Value, fid: Hash) =
 
     try:
         if not meth.mbcode.isNil:
-            ExecLoop(meth.mbcode().trans.constants, fun.mbcode().trans.instructions)
+            ExecLoop(meth.mbcode().trans.constants, meth.mbcode().trans.instructions)
         else:
             let (trans, storable) = doEvalAndCheckSafety(meth.mmain, isFunctionBlock=true)
             if storable:

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -388,7 +388,7 @@ proc execFunction*(fun: Value, fid: Hash) =
         if not fun.bcode.isNil:
             ExecLoop(fun.bcode().trans.constants, fun.bcode().trans.instructions)
         else:
-            let (trans, storable) = doEvalAndCheckSafety(fun.main, isFunctionBlock)
+            let (trans, storable) = doEvalAndCheckSafety(fun.main, isFunctionBlock=true)
             if storable:
                 fun.bcode = newBytecode(trans)
             ExecLoop(trans.constants, trans.instructions)
@@ -455,7 +455,7 @@ proc execFunctionInline*(fun: Value, fid: Hash) =
         if not fun.bcode.isNil:
             ExecLoop(fun.bcode().trans.constants, fun.bcode().trans.instructions)
         else:
-            let (trans, storable) = doEvalAndCheckSafety(fun.main, isFunctionBlock)
+            let (trans, storable) = doEvalAndCheckSafety(fun.main, isFunctionBlock=true)
             if storable:
                 fun.bcode = newBytecode(trans)
             ExecLoop(trans.constants, trans.instructions)
@@ -499,7 +499,7 @@ proc execMethod*(meth: Value, fid: Hash) =
         if not meth.mbcode.isNil:
             ExecLoop(meth.mbcode().trans.constants, fun.mbcode().trans.instructions)
         else:
-            let (trans, storable) = doEvalAndCheckSafety(meth.mmain, isFunctionBlock)
+            let (trans, storable) = doEvalAndCheckSafety(meth.mmain, isFunctionBlock=true)
             if storable:
                 meth.mbcode = newBytecode(trans)
             ExecLoop(trans.constants, trans.instructions)


### PR DESCRIPTION
# Description

Right now, this:

```ruby
define :person [
    init: constructor [
        name :string
        surname :string
    ]

    check: method [][
        inspect this
    ]
]

define :personWrapper [
    init: method [n, s][
        \pers: to :person @[n, s]
    ]

    doSth: method [][
        \pers\check
    ]
]

a: to :personWrapper ["John" "Doe"]!
a\doSth

b: to :personWrapper ["Jane" "Doe"]!
b\doSth
```

leads to this:

```
[ :person
        name     :        John :string
        surname  :        Doe :string
]
[ :person
        name     :        John :string
        surname  :        Doe :string
]
```

The cause is that `this\pers` inside `doSth` has already been embedded the first time the function was evaluated. And since - for performance reasons - we tend to store evaluated blocks (apparently, a bit too much), the next time this function is called, with a different object, the same one is getting served 🤦🏻‍♂️ .

So, let's fix it! 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
