### PR TITLE
Fix minor error in 'var' example

### DIFF
--- a/src/library/Core.nim
+++ b/src/library/Core.nim
@@ -1329,7 +1329,7 @@ proc defineLibrary*() =
         returns     = {Any},
         example     = """
             a: 2
-            print var 'a            ; a
+            print var 'a            ; 2
 
             f: function [x][x+2]
             print f 10              ; 12

--- a/src/library/Core.nim
+++ b/src/library/Core.nim
@@ -466,7 +466,7 @@ proc defineLibrary*() =
 
             print "good, the number is positive indeed. let's continue..."
             ..........
-            ensure.message: "Wrong calc" ->  0 = 1 + 1
+            ensure.that: "Wrong calc" ->  0 = 1 + 1
             ; >> Assertion | "Wrong calc": [0 = 1 + 1]
             ;        error |
         """:


### PR DESCRIPTION
# Var example fix

Only changed one line in builtin 'var' example string, it should show 2 instead of a when `print var 'a` is performed. No other changes has been made 

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (documentation-related additions)