### PR TITLE
fixes `LinenoiseCompletions` types incompatible with gcc 14

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -29,7 +29,6 @@ proc defaultConfig() =
     if hostOS != "windows": 
         --passL:"-pthread"
     --path:src
-    --passC:"-Wno-error=incompatible-pointer-types"
 
 
 proc configGMPOnWindows() =

--- a/src/extras/linenoise.nim
+++ b/src/extras/linenoise.nim
@@ -51,7 +51,7 @@ type
 
 {.push header: "linenoise/linenoise.h", cdecl.}
 
-proc linenoiseSetCompletionCallback*(cback: LinenoiseCompletionCallback, userdata: pointer): ptr LinenoiseCompletionCallback {.importc: "linenoiseSetCompletionCallback".}
+proc linenoiseSetCompletionCallback*(cback: LinenoiseCompletionCallback, userdata: pointer): LinenoiseCompletionCallback {.importc: "linenoiseSetCompletionCallback".}
 proc linenoiseSetHintsCallback*(callback: LinenoiseHintsCallback, userdata: pointer) {.importc: "linenoiseSetHintsCallback".}
 proc linenoiseAddCompletion*(a2: ptr LinenoiseCompletions; a3: cstring) {.importc: "linenoiseAddCompletion".}
 proc linenoiseReadLine*(prompt: cstring): cstring {.importc: "linenoise".}

--- a/src/extras/linenoise.nim
+++ b/src/extras/linenoise.nim
@@ -37,7 +37,7 @@ import os
 
 type
     constChar* {.importc:"const char*".} = cstring
-    LinenoiseCompletions* {.bycopy.} = object
+    LinenoiseCompletions* {.bycopy, importc: "linenoiseCompletions".} = object
       len*: csize_t
       cvec*: cstringArray
 

--- a/src/extras/linenoise.nim
+++ b/src/extras/linenoise.nim
@@ -52,7 +52,7 @@ type
 {.push header: "linenoise/linenoise.h", cdecl.}
 
 proc linenoiseSetCompletionCallback*(cback: LinenoiseCompletionCallback, userdata: pointer): ptr LinenoiseCompletionCallback {.importc: "linenoiseSetCompletionCallback".}
-proc linenoiseSetHintsCallback*(callback: ptr LinenoiseHintsCallback, userdata: pointer) {.importc: "linenoiseSetHintsCallback".}
+proc linenoiseSetHintsCallback*(callback: LinenoiseHintsCallback, userdata: pointer) {.importc: "linenoiseSetHintsCallback".}
 proc linenoiseAddCompletion*(a2: ptr LinenoiseCompletions; a3: cstring) {.importc: "linenoiseAddCompletion".}
 proc linenoiseReadLine*(prompt: cstring): cstring {.importc: "linenoise".}
 proc linenoiseHistoryAdd*(line: cstring): cint {.importc: "linenoiseHistoryAdd", discardable.}

--- a/src/extras/linenoise.nim
+++ b/src/extras/linenoise.nim
@@ -51,7 +51,7 @@ type
 
 {.push header: "linenoise/linenoise.h", cdecl.}
 
-proc linenoiseSetCompletionCallback*(cback: ptr LinenoiseCompletionCallback, userdata: pointer): ptr LinenoiseCompletionCallback {.importc: "linenoiseSetCompletionCallback".}
+proc linenoiseSetCompletionCallback*(cback: LinenoiseCompletionCallback, userdata: pointer): ptr LinenoiseCompletionCallback {.importc: "linenoiseSetCompletionCallback".}
 proc linenoiseSetHintsCallback*(callback: ptr LinenoiseHintsCallback, userdata: pointer) {.importc: "linenoiseSetHintsCallback".}
 proc linenoiseAddCompletion*(a2: ptr LinenoiseCompletions; a3: cstring) {.importc: "linenoiseAddCompletion".}
 proc linenoiseReadLine*(prompt: cstring): cstring {.importc: "linenoise".}

--- a/src/extras/md4c.nim
+++ b/src/extras/md4c.nim
@@ -3,7 +3,7 @@
 {.compile: "md4c/entity.c".}
 
 type 
-    memBuffer* = ref object
+    memBuffer* {.importc: "struct membuffer", bycopy.} = object
         data*: cstring
         asize*: csize_t
         size*: csize_t
@@ -13,10 +13,10 @@ type
 func toMarkdown*(
     input: cstring, 
     input_size: cint, 
-    userdata: memBuffer, 
+    userdata: ptr memBuffer, 
     parser_flags: cint, 
     renderer_flags: cint): cint {.importc: "toMarkdown",header: "<md4c/md4c-html.h>".}
 
 func freeMarkdownBuffer*(
-    userdata: memBuffer,
+    userdata: ptr memBuffer,
 ) {.importc: "membuf_fini",header: "<md4c/md4c-html.h>".}

--- a/src/helpers/markdown.nim
+++ b/src/helpers/markdown.nim
@@ -34,8 +34,8 @@ when not defined(NOPARSERS):
     else:
         func parseMarkdownInput*(input: string): Value =
             var ret: memBuffer = memBuffer(size: 0, asize: 0, data: "")
-            discard toMarkdown( cstring(input), cint(len(input)),ret,0,0)
+            discard toMarkdown( cstring(input), cint(len(input)), addr ret,0,0)
             var str = newString(ret.size)
             copyMem(addr(str[0]), ret.data, ret.size)
-            freeMarkdownBuffer(ret)
+            freeMarkdownBuffer(addr ret)
             return newString(str)

--- a/src/helpers/repl.nim
+++ b/src/helpers/repl.nim
@@ -80,8 +80,7 @@ when not defined(WEB):
                 createDir(parentDir(path))
             discard linenoiseHistoryLoad(path)
 
-            var completionCallback: LinenoiseCompletionCallback = completionsCback
-            discard linenoiseSetCompletionCallback(addr completionCallback, nil)
+            discard linenoiseSetCompletionCallback(completionsCback, nil)
 
             var hintCallback: ptr LinenoiseHintsCallback = cast[ptr LinenoiseHintsCallback](hintsCback)
             linenoiseSetHintsCallback(hintCallback, nil)

--- a/src/helpers/repl.nim
+++ b/src/helpers/repl.nim
@@ -80,8 +80,8 @@ when not defined(WEB):
                 createDir(parentDir(path))
             discard linenoiseHistoryLoad(path)
 
-            var completionCallback: ptr LinenoiseCompletionCallback = cast[ptr LinenoiseCompletionCallback](completionsCback)
-            discard linenoiseSetCompletionCallback(completionCallback, nil)
+            var completionCallback: LinenoiseCompletionCallback = completionsCback
+            discard linenoiseSetCompletionCallback(addr completionCallback, nil)
 
             var hintCallback: ptr LinenoiseHintsCallback = cast[ptr LinenoiseHintsCallback](hintsCback)
             linenoiseSetHintsCallback(hintCallback, nil)

--- a/src/helpers/repl.nim
+++ b/src/helpers/repl.nim
@@ -82,8 +82,7 @@ when not defined(WEB):
 
             discard linenoiseSetCompletionCallback(completionsCback, nil)
 
-            var hintCallback: ptr LinenoiseHintsCallback = cast[ptr LinenoiseHintsCallback](hintsCback)
-            linenoiseSetHintsCallback(hintCallback, nil)
+            linenoiseSetHintsCallback(hintsCback, nil)
 
             ReplInitialized = true
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue/s)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


ref https://forum.nim-lang.org/t/11612