### PR TITLE
[Reflection\attr?] update the docs to cover behavior

### DIFF
--- a/src/library/Reflection.nim
+++ b/src/library/Reflection.nim
@@ -344,17 +344,22 @@ proc defineLibrary*() =
         returns     = {Logical},
         example     = """
             greet: function [x][
-                if? not? attr? 'later [
-                    print ["Hello" x "!"]
-                ]
-                else [
-                    print [x "I'm afraid I'll greet you later!"]
-                ]
+                switch attr? 'later
+                  -> ~"|x| I'm afraid, I'll greet you later"
+                  -> ~"Hello, |x|!"
             ]
             
+            greet "John"
+            ; => Hello, John!
+
             greet.later "John"
+            ; => John I'm afraid, I'll greet you later!
             
-            ; John I'm afraid I'll greet you later!
+            ; Have in mind that `attr?` won't pop your attribute's stack
+            
+            greet "Joe"
+            ; => Joe I'm afraid, I'll greet you later!
+            
         """:
             #=======================================================
             if getAttr(x.s) != VNULL:


### PR DESCRIPTION
# Description

Shows that `attr?` does not pop the attributes' stack.

Related: https://discord.com/channels/765519132186640445/1245435661495046144
Thanks to @BNAndras.

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (documentation-related additions)