### PR TITLE
docs: update symbols link

### DIFF
--- a/docs/website/pages/documentation/language.art
+++ b/docs/website/pages/documentation/language.art
@@ -133,7 +133,7 @@ Some of the existing *aliases* in the built-in dictionary:
 %ALIAS_LIST%
 </table>
 
-> 💡 For the complete of recognized symbols in Arturo, you may have a look at <a href="https://github.com/arturo-lang/arturo/blob/master/src/vm/values/value.nim#L52-L142" target="_blank">here</a>.
+> 💡 For the complete of recognized symbols in Arturo, you may have a look at <a href="https://github.com/arturo-lang/arturo/blob/master/src/vm/values/custom/vsymbol.nim#L21-L124" target="_blank">here</a>.
 
 <h3 id="values">Values</h3>
 


### PR DESCRIPTION
# Description


The language documentation has this section:

>💡 For the complete of recognized symbols in Arturo, you may have a look at here.

However, looking at the highlighted code, I don't really see the symbols.

Fixes https://github.com/arturo-lang/arturo-lang.io/issues/7

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (documentation-related additions)