### PR TITLE
 Collections: Fix .by: in permutate and combine for values <= 0 and bigger than length.

### DIFF
--- a/src/helpers/combinatorics.nim
+++ b/src/helpers/combinatorics.nim
@@ -26,7 +26,10 @@ import vm/values/operators
 
 proc repeatedPermutations(a: ValueArray, n: int): seq[ValueArray] =
     result = newSeq[ValueArray]()
-    if n <= 0: return
+    if n < 0: return
+    if n == 0:
+        result.add(@[])
+        return result
     for i in 0 .. a.high:
         if n == 1:
             result.add(@[a[i]])
@@ -36,7 +39,10 @@ proc repeatedPermutations(a: ValueArray, n: int): seq[ValueArray] =
 
 proc uniquePermutations(a: ValueArray, n: int, used: var seq[bool]): seq[ValueArray] =
     result = newSeq[ValueArray]()
-    if n <= 0: return
+    if n < 0: return
+    if n == 0:
+        result.add(@[])
+        return result
     for i in 0 .. a.high:
         if not used[i]:
             if n == 1:
@@ -50,7 +56,10 @@ proc uniquePermutations(a: ValueArray, n: int, used: var seq[bool]): seq[ValueAr
 proc repeatedCombinations(a: ValueArray; n: int; used: seq[bool]): seq[ValueArray] =
     result = newSeq[ValueArray]()
     var used = used
-    if n <= 0: return
+    if n < 0: return
+    if n == 0:
+        result.add(@[])
+        return result
     for i in 0  .. a.high:
         if not used[i]:
             if n == 1:
@@ -63,7 +72,10 @@ proc repeatedCombinations(a: ValueArray; n: int; used: seq[bool]): seq[ValueArra
 proc uniqueCombinations(a: ValueArray; n: int; used: seq[bool]): seq[ValueArray] =
     result = newSeq[ValueArray]()
     var used = used
-    if n <= 0: return
+    if n < 0: return
+    if n == 0:
+        result.add(@[])
+        return result
     for i in 0  .. a.high:
         if not used[i]:
             if n == 1:
@@ -90,10 +102,12 @@ func getCombinations*(lst: ValueArray, size: int, repeated: bool = false): seq[V
 
 proc countPermutations*(lst: ValueArray, size: int, repeated: bool = false): Value =
     let n = lst.len
-    if repeated: newInteger(n) ^ newInteger(size)
+    if size < 0 or (size > n and not repeated): newInteger(0)
+    elif repeated: newInteger(n) ^ newInteger(size)
     else: factorial(n) / factorial(n-size)
 
 proc countCombinations*(lst: ValueArray, size: int, repeated: bool = false): Value =
     let n = lst.len
-    if repeated: factorial(n+size-1) / (factorial(size)*factorial(n-1))
+    if size < 0 or (size > n and not repeated): newInteger(0)
+    elif repeated: factorial(n+size-1) / (factorial(size)*factorial(n-1))
     else: factorial(n) / (factorial(size)*factorial(n-size))

--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -302,16 +302,6 @@ proc defineLibrary*() =
     # TODO(Collections\combine) should also work with in-place Literals?
     #  labels: library, enhancement, open discussion
 
-    # TODO(Collections\combine) should follow the rule: C[n:k] = 0, for k > n
-    #  being k the attribute by, n the size of the collection and 
-    #  C the amount of possible combinations:
-    #
-    #  ```art
-    #  ensure -> empty? combine.by: 4 [a b c] 
-    #  ensure -> empty? combine.by: 5 [a b c] 
-    #  ensure -> empty? combine.by: 6 [a b c] 
-    #  ``` 
-    # labels: library, open-discussion
     builtin "combine",
         alias       = unaliased,
         op          = opNop,
@@ -338,6 +328,10 @@ proc defineLibrary*() =
 
             combine.repeated.by:2 [A B C]
             ; => [[A A] [A B] [A C] [B B] [B C] [C C]]
+
+            combine.repeated.by: 3 [A B]
+            ; => [[A A A] [A A B] [A B B] [B B B]]
+
             ..........
             combine.count [A B C]
             ; => 1
@@ -350,8 +344,7 @@ proc defineLibrary*() =
 
             var sz = x.a.len
             if checkAttr("by"):
-                if aBy.i > 0 and aBy.i < sz:
-                    sz = aBy.i
+                sz = aBy.i
 
             if hadAttr("count"):
                 push(countCombinations(x.a, sz, doRepeat))
@@ -1218,6 +1211,10 @@ proc defineLibrary*() =
 
             permutate.repeated.by:2 [A B C]
             ; => [[A A] [A B] [A C] [B A] [B B] [B C] [C A] [C B] [C C]]
+
+            permutate.repeated.by:3 [A B]
+            ; => [[A A A] [A A B] [A B A] [A B B] [B A A] [B A B] [B B A] [B B B]]
+
             ..........
             permutate.count [A B C]
             ; => 6
@@ -1230,8 +1227,7 @@ proc defineLibrary*() =
 
             var sz = x.a.len
             if checkAttr("by"):
-                if aBy.i > 0 and aBy.i < sz:
-                    sz = aBy.i
+                sz = aBy.i
 
             if hadAttr("count"):
                 push(countPermutations(x.a, sz, doRepeat))

--- a/tests/unitt/lib/collections/combine.test.art
+++ b/tests/unitt/lib/collections/combine.test.art
@@ -40,7 +40,8 @@ suite "General Tests" [
     ]
 
     test.prop ".count is the size of the combination" [
-        operations: [[combine.by: 2] [combine.repeated] [combine.repeated.by: 2]]
+        operations: [[combine.by: 2] [combine.repeated] [combine.repeated.by: 2]
+                     [combine.by:0] [combine.repeated.by: 0]]
         loop operations 'op [
             counted: (op ++ [.count someBlock])
             sized: ([size] ++ op ++ [someBlock])
@@ -65,8 +66,12 @@ suite "Matematical Properties" [
         assert -> 1 = combine.count.by: 0 someBlock 
     ]
 
-    test.prop.skip "C[n:k] = 0, for all k > n" [
+    test.prop "C[n:k] = 0, for all k > n" [
         assert -> 0 = combine.count.by: (inc size someBlock) someBlock
+    ]
+
+    test.prop "C[n:k] = 0, for all k < 0" [
+        assert -> 0 = combine.count.by: (neg 1) someBlock
     ]
 
     test.prop "C[n:k] = n! / (k! * (n - k)!)" [
@@ -115,6 +120,13 @@ suite "Specific Tests" [
 
         assert -> result = combine.repeated.by: 2 [A B C]
         assert -> equal? size result combine.count.repeated.by: 2 [A B C]
+    ]
+
+    test "combine.repeated.by: 3 [A B]" [
+        result: [[A A A] [A A B] [A B B] [B B B]]
+
+        assert -> result = combine.repeated.by: 3 [A B]
+        assert -> equal? size result combine.count.repeated.by: 3 [A B]
     ]
 
 ]

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -1118,6 +1118,19 @@ do [
     ensure -> 9 = permutate.count.repeated.by:2 [A B C]
     passed
 
+    ensure -> 1 = permutate.count.by: 0 [A B C]
+    passed
+    ensure -> [[]] = permutate.by: 0 [A B C]
+    passed
+    ensure -> 0 = permutate.count.by: 10 [A B C]
+    passed
+    ensure -> [] = permutate.by: 10 [A B C]
+    passed
+    ensure -> 8 = permutate.count.repeated.by: 3 [A B]
+    passed
+    ensure -> [[A A A] [A A B] [A B A] [A B B] [B A A] [B A B] [B B A] [B B B]]
+        = permutate.repeated.by:3 [A B]
+    passed
 
 ]
 

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -316,6 +316,12 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
+[+] passed!
 
 >> pop
 


### PR DESCRIPTION
# Description

Collections: allow bigger sizes for `combine` and `permutate` with `.repeated` option.
https://discord.com/channels/765519132186640445/1283495508354011219

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (documentation-related additions)

closes https://github.com/arturo-lang/arturo/issues/1605