### PR TITLE
Add Windows support for executable package aliases

### DIFF
--- a/src/vm/packager.nim
+++ b/src/vm/packager.nim
@@ -560,8 +560,12 @@ proc processRemotePackage(pkg: string, verspec: VersionSpec, doLoad: bool = true
             let (packageLocation, _) = localPackage.get()
             if (let executableFile = packageLocation / executable.get(); executableFile.fileExists()):
                 createDir(BinFolder.fmt)
-                let executableDest = BinFolder.fmt / pkg
-                writeToFile(executableDest, "#!/usr/bin/env bash\narturo {executableFile} \"$@\"".fmt)
+                when defined(windows):
+                    let executableDest = BinFolder.fmt / "{pkg}.bat".fmt
+                    writeToFile(executableDest, "{executableFile} %*".fmt)
+                else:
+                    let executableDest = BinFolder.fmt / pkg
+                    writeToFile(executableDest, "#!/usr/bin/env bash\narturo {executableFile} \"$@\"".fmt)
                 setFilePermissions(executableDest, {fpUserRead, fpUserWrite, fpUserExec, fpGroupRead, fpGroupWrite, fpGroupExec, fpOthersRead, fpOthersWrite, fpOthersExec})
 
     try:


### PR DESCRIPTION
# Description

Currently, executable packages don't have aliases that function properly in Windows. This should solve that.

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (documentation-related additions)