### PR TITLE
Add support for executable package aliases in Windows (fixed)

### DIFF
--- a/src/vm/packager.nim
+++ b/src/vm/packager.nim
@@ -562,7 +562,7 @@ proc processRemotePackage(pkg: string, verspec: VersionSpec, doLoad: bool = true
                 createDir(BinFolder.fmt)
                 when defined(windows):
                     let executableDest = BinFolder.fmt / "{pkg}.bat".fmt
-                    writeToFile(executableDest, "{executableFile} %*".fmt)
+                    writeToFile(executableDest, "@echo off\narturo {executableFile} %*".fmt)
                 else:
                     let executableDest = BinFolder.fmt / pkg
                     writeToFile(executableDest, "#!/usr/bin/env bash\narturo {executableFile} \"$@\"".fmt)


### PR DESCRIPTION
# Description

Fix for previous PR. This should now correctly call arturo and also suppress the command output for that.

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (documentation-related additions)