### PR TITLE
Remove executable package alias when uninstalling in Windows

### DIFF
--- a/src/vm/packager.nim
+++ b/src/vm/packager.nim
@@ -246,8 +246,12 @@ proc removeLocalPackage(pkg: string, version: VVersion): bool =
         let specPath = SpecPackage.fmt
         removeDir(specPath)
 
-        let executableDest = BinFolder.fmt / pkg
-        discard tryRemoveFile(executableDest)
+        when defined(windows):
+            let executableDest = BinFolder.fmt / "{pkg}.bat".fmt
+            discard tryRemoveFile(executableDest)
+        else:
+            let executableDest = BinFolder.fmt / pkg
+            discard tryRemoveFile(executableDest)
     
     ShowSuccess()
 


### PR DESCRIPTION
# Description

This change deletes executable package aliases when uninstalling packages in Windows.

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (documentation-related additions)