### PR TITLE
Fix in? magic method

### DIFF
--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2762,7 +2762,7 @@ proc defineLibrary*() =
                         let values = toSeq(y.d.values)
                         push(newLogical(values[at] == x))
                     of Object:
-                        if unlikely(x.magic.fetch(ContainsQM)):
+                        if unlikely(y.magic.fetch(ContainsQM)):
                             pushAttr("at", aAt)
                             mgk(@[y, x]) # already pushes value
                         else:
@@ -2794,7 +2794,7 @@ proc defineLibrary*() =
                             let values = toSeq(y.d.values)
                             push(newLogical(x in values))
                     of Object:
-                        if unlikely(x.magic.fetch(ContainsQM)):
+                        if unlikely(y.magic.fetch(ContainsQM)):
                             if hadAttr("deep"):
                                 pushAttr("deep", VTRUE)
 


### PR DESCRIPTION
# Description
Fixes the behavior of magic method `in?`
 ```
define :set [
	init: constructor [predicate]
	contains?: method [item][
		call \predicate @[item]
	]
]

iseven: function 'x [(x % 2) = 0]
even: to :set ['iseven]!

print contains? even 2
print in? 2 even
print 2 ∈ even
```

used to output `true false false`. Now it outputs `true true true`.

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (documentation-related additions)