### PR TITLE
[Sockets\listen] remove `.blocking` option

### DIFF
--- a/src/library/Sockets.nim
+++ b/src/library/Sockets.nim
@@ -133,7 +133,6 @@ proc defineLibrary*() =
                 "port"  : {Integer}
             },
             attrs       = {
-                "blocking"  : ({Logical},"set blocking mode (default: false)"),
                 "udp"       : ({Logical},"use UDP instead of TCP")
             },
             returns     = {Socket},
@@ -144,7 +143,7 @@ proc defineLibrary*() =
                 #=======================================================
                 when defined(SAFE): Error_OperationNotPermitted("listen")
 
-                let blocking = hadAttr("blocking")
+                let blocking = true
                 let protocol = 
                     if hadAttr("udp"): IPPROTO_UDP
                     else: IPPROTO_TCP

--- a/src/library/Sockets.nim
+++ b/src/library/Sockets.nim
@@ -59,7 +59,7 @@ proc defineLibrary*() =
             attrs       = NoAttrs,
             returns     = {Socket},
             example     = """
-            server: listen.blocking 18966
+            server: listen 18966
             print "started server connection..."
 
             client: accept server
@@ -175,7 +175,7 @@ proc defineLibrary*() =
             },
             returns     = {String},
             example     = """
-            server: listen.blocking 18966
+            server: listen 18966
             print "started server connection..."
 
             client: accept server


### PR DESCRIPTION
# Description

Basically, the only thing Arturo currently supports (and quite well, actually) is *blocking* connections, hence all of the examples so far were with `listen.blocking`.

Instead of doing it like this, this PR:

- completely removes the `.blocking` option
- internally sets it as the default mode

And if in the future we actually add support for *non-blocking* sockets, we could add an `.async` option for that...

## Type of change

- [x] Code cleanup
- [x] Enhancement (implementation update, or general performance enhancements)
