### PR TITLE
[Collections\couple] Migrate tests to `unitt`

### DIFF
--- a/tests/unitt/lib/collections/couple.test.art
+++ b/tests/unitt/lib/collections/couple.test.art
@@ -1,0 +1,19 @@
+import {unitt}!
+import relative {../../commons/functions}!
+
+test "returns tuples" [
+    expected: [[a a] [b b] [c c]]
+    actual: couple [a b c] [a b c]
+    assert -> expected = actual
+    assert -> every? actual 'el [2 = size el]
+]
+
+test "keeps the order" [
+    expected: [["one" 1] ["two" 2] ["three" 3]]
+    actual: couple ["one" "two" "three"] [1 2 3]
+
+    assert -> expected = actual
+]
+
+; todo(Collections\couple): add tests for inplace-equivalence after add this feature.
+;   ref: #1786

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -9,13 +9,6 @@ passed: $[] -> print "[+] passed!"
 
 ; ==> Tests
 
-; couple don't support literals yet
-topic "couple"
-do [
-    ensure -> [["one" 1] ["two" 2] ["three" 3]] = couple ["one" "two" "three"] [1 2 3]
-    passed
-]
-
 topic "decouple"
 do [
     ensure -> [["one" "two" "three"] [1 2 3]] = decouple [["one" 1] ["two" 2] ["three" 3]]

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -1,7 +1,4 @@
 
->> couple
-[+] passed!
-
 >> decouple
 [+] passed!
 [+] passed!


### PR DESCRIPTION
# Description

Migrates tests to `unitt`. Since #1786 added the feature of accept literals, as it is for `decouple`, I think this should be better to be solved in another PR. :wink:

- Ref.: #1786

## Type of change

- [ ] Code cleanup
- [x] Unit tests (added or updated unit-tests)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (documentation-related additions)