### PR TITLE
Fix typo in `or?` example

### DIFF
--- a/src/library/Logic.nim
+++ b/src/library/Logic.nim
@@ -317,7 +317,7 @@ proc defineLibrary*() =
             y: 4
             
             if or? x=2 y>5 [
-                print "yep, that's correct!"]
+                print "yep, that's correct!"
             ]
             
             ; yep, that's correct!


### PR DESCRIPTION
# Description

Typo reported by SamwiseTheBrave at https://discord.com/channels/765519132186640445/829324913097048065/1330200600599728218.

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (documentation-related additions)