### PR TITLE
Remove formatting issues in docs related to  HTML tags

### DIFF
--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2380,7 +2380,7 @@ proc defineLibrary*() =
         alias       = unaliased,
         op          = opNop,
         rule        = PrefixPrecedence,
-        description = "keep first <number> of elements from given collection and return the remaining ones",
+        description = "keep first N elements from given collection and return the remaining ones",
         args        = {
             "collection": {String, Block, Range, Literal, PathLiteral},
             "number"    : {Integer}

--- a/src/library/Core.nim
+++ b/src/library/Core.nim
@@ -1336,7 +1336,7 @@ proc defineLibrary*() =
         alias       = unaliased, 
         op          = opNop,
         rule        = PrefixPrecedence,
-        description = "pop top <number> values from stack",
+        description = "pop top N values from stack",
         args        = {
             "number"    : {Integer}
         },


### PR DESCRIPTION
# Description

These two function descriptions contain text between angle brackets. It seems this gets formatted as HTML and then not properly rendered. 
![image](https://github.com/user-attachments/assets/7d41ba54-031d-4ef8-9227-2ecd5ae4dd08)

The corresponding HTML is ```<h3 class="subtitle is-4 is-spaced">pop top<number>values from stack</number></h3>```.

I changed number to N since that reads a little clearer to me. 

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (documentation-related additions)