### PR TITLE
[Collections/split] implement split.by support for `:char`

### DIFF
--- a/src/library/Collections.nim
+++ b/src/library/Collections.nim
@@ -2223,7 +2223,7 @@ proc defineLibrary*() =
         attrs       = {
             "words" : ({Logical}, "split string by whitespace"),
             "lines" : ({Logical}, "split string by lines"),
-            "by"    : ({String, Regex, Block}, "split using given separator"),
+            "by"    : ({String, Regex, Char, Block}, "split using given separator"),
             "at"    : ({Integer}, "split collection at given position"),
             "every" : ({Integer}, "split collection every *n* elements"),
             "path"  : ({Logical}, "split path components in string")
@@ -2269,6 +2269,8 @@ proc defineLibrary*() =
                     elif checkAttr("by"):
                         if aBy.kind == String:
                             SetInPlaceAny(newStringBlock(InPlaced.s.split(aBy.s)))
+                        elif aBy.kind == Char:
+                            SetInPlaceAny(newStringBlock(InPlaced.s.split(aBy.c)))
                         elif aBy.kind == Regex:
                             SetInPlaceAny(newStringBlock(InPlaced.s.split(aBy.rx)))
                         else:
@@ -2330,6 +2332,8 @@ proc defineLibrary*() =
                 elif checkAttr("by"):
                     if aBy.kind == String:
                         push(newStringBlock(x.s.split(aBy.s)))
+                    elif aBy.kind == Char:
+                        push(newStringBlock(x.s.split(aBy.c)))
                     elif aBy.kind == Regex:
                         push(newStringBlock(x.s.split(aBy.rx)))
                     else:

--- a/tests/unittests/lib.collections.art
+++ b/tests/unittests/lib.collections.art
@@ -2631,6 +2631,10 @@ do [
         = split.by: {/,/} "Arturo, Nim, Ruby, Python, C, CoffeeScript"
     passed
 
+    ensure -> ["Arturo" " Nim" " Ruby" " Python", " C", " CoffeeScript"]
+        = split.by: ',' "Arturo, Nim, Ruby, Python, C, CoffeeScript"
+    passed
+
     sample: {
         Arturo is an independently-developed,
         modern programming language,

--- a/tests/unittests/lib.collections.res
+++ b/tests/unittests/lib.collections.res
@@ -646,6 +646,7 @@
 [+] passed!
 [+] passed!
 [+] passed!
+[+] passed!
 
 >> split - .by (literal)
 [+] passed!


### PR DESCRIPTION
# At A Glance

![image](https://github.com/user-attachments/assets/2a1b9b0d-56c1-422e-a423-4c447d6b6014)
![image](https://github.com/user-attachments/assets/96900358-a728-4daa-8efe-63ad0809e5d9)


Fixes #1874

## Type of change

- [ ] Code cleanup
- [x] Unit tests (added or updated unit-tests)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (documentation-related additions)