### PR TITLE
[Core\unstack] Deprecate `unstack.discard`

### DIFF
--- a/src/library/Core.nim
+++ b/src/library/Core.nim
@@ -1437,9 +1437,7 @@ proc defineLibrary*() =
         args        = {
             "number"    : {Integer}
         },
-        attrs       = {
-            "discard"   : ({Logical},"do not return anything")
-        },
+        attrs       = NoAttrs,
         returns     = {Any},
         example     = """
             1 2 3
@@ -1456,21 +1454,14 @@ proc defineLibrary*() =
                 Error_StackUnderflow()
             
             if x.i==1:
-                if doDiscard: discard stack.pop()
-                else: discard
+                discard
             else:
-                if doDiscard: 
-                    var i = 0
-                    while i<x.i:
-                        discard stack.pop()
-                        i+=1
-                else:
-                    var res: ValueArray
-                    var i = 0
-                    while i<x.i:
-                        res.add stack.pop()
-                        i+=1
-                    push(newBlock(res))
+                var res: ValueArray
+                var i = 0
+                while i<x.i:
+                    res.add stack.pop()
+                    i+=1
+                push(newBlock(res))
 
     builtin "until",
         alias       = unaliased, 

--- a/src/library/Core.nim
+++ b/src/library/Core.nim
@@ -1446,8 +1446,9 @@ proc defineLibrary*() =
             1 2 3
             b: unstack 2        ; b: [3 2]
             ..........
+            ; You can also discard the values using `discard`
             1 2 3
-            unstack.discard 1   ; popped 3 from the stack
+            discard unstack 1   ; popped 3 from the stack
         """:
             #=======================================================
             if Stack[0..SP-1].len < x.i: 

--- a/src/library/Core.nim
+++ b/src/library/Core.nim
@@ -1452,9 +1452,8 @@ proc defineLibrary*() =
             unstack.discard 1   ; popped 3 from the stack
         """:
             #=======================================================
-            if Stack[0..SP-1].len < x.i: Error_StackUnderflow()
-            
-            let doDiscard = (hadAttr("discard"))
+            if Stack[0..SP-1].len < x.i: 
+                Error_StackUnderflow()
             
             if x.i==1:
                 if doDiscard: discard stack.pop()

--- a/src/scripts/console.art
+++ b/src/scripts/console.art
@@ -176,7 +176,7 @@ lookup: function [what :string :literal :regex :type][
     ]
 
     PrintFList results "found"
-    unstack.discard size stack
+    discard unstack size stack
 ]
 
 Repl: #[autocomplete?: true, hints?: true, verbose?: true]


### PR DESCRIPTION
# Description

Updates Documentation (with the example of the `discard` function) and deprecates the attribute. Also updates depending parts of the deprecated one, like the `console.art`.

Fixes #1870

## Demo

![image](https://github.com/user-attachments/assets/7d5a4d31-b357-473b-b545-182929fa33b6)
![image](https://github.com/user-attachments/assets/62d6d962-bd3a-40a5-a79a-62c261443c25)


## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (documentation-related additions)