### PR TITLE
Add support for `:path` to `:block` conversions

### DIFF
--- a/src/helpers/conversion.nim
+++ b/src/helpers/conversion.nim
@@ -540,7 +540,10 @@ proc convertedValueToType*(x, y: Value, tp: ValueKind, aFormat:Value = nil): Val
             of Path,
                PathLabel,
                PathLiteral:
-                throwCannotConvert()
+                if tp == Block:
+                    return newBlock(y.p)
+                else:
+                    throwCannotConvert()
 
             of Symbol:
                 case tp:

--- a/src/helpers/conversion.nim
+++ b/src/helpers/conversion.nim
@@ -537,6 +537,11 @@ proc convertedValueToType*(x, y: Value, tp: ValueKind, aFormat:Value = nil): Val
                     else:
                         throwCannotConvert()
 
+            of Path,
+               PathLabel,
+               PathLiteral:
+                throwCannotConvert()
+
             of Symbol:
                 case tp:
                     of String:
@@ -634,7 +639,4 @@ proc convertedValueToType*(x, y: Value, tp: ValueKind, aFormat:Value = nil): Val
                Database,
                Socket,
                Nothing,
-               Any,
-               Path,
-               PathLabel,
-               PathLiteral: throwCannotConvert()
+               Any: throwCannotConvert()


### PR DESCRIPTION
# Description

It could also handle: 

- `:pathLabel`
- `:pathLiteral`

since they are quite similar.

> [!NOTE]
> The PR isn't anything high-priority or urgent, just me using it as an "easy-entry" excuse to get back to working on 🦂... hehe)

Fixes #1640

## Type of change

- [x] New feature (non-breaking change which adds functionality)
