### PR TITLE
Make full builds include documentation by default

### DIFF
--- a/.config/buildmode.nims
+++ b/.config/buildmode.nims
@@ -43,6 +43,7 @@ proc fullBuildConfig() =
         
         --passL:"-Wl,-headerpad_max_install_names"
     --define:ssl
+    --define:DOCGEN
 
 proc docgenBuildConfig() =
     fullBuildConfig()


### PR DESCRIPTION
# Description

Basically, this is about (temporarily?) forcing `--define:DOCGEN` on all full builds.

**The reason is three-fold:**

- I don't think the disadvantages are as bad as I though (the difference in binary sizes is negligible & performance-wise, I'm not sure there is *any* whatsoever)
- We save ourselves the pain of maintaining too many configurations (and/or e.g. having to compile a separate binary just to deploy the website documentation, etc)
- Opens the door to re-enabling our ["examples in the REPL" long-gone feature](https://github.com/arturo-lang/arturo/issues/2043)

Now, if the experiment succeeds, we could proceed to completely eliminate the whole `DOCGEN` thing (and clean up our build script). But - until then - let's wait and see... 😉 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (documentation-related additions)