### PR TITLE
Fix attr example

### DIFF
--- a/src/library/Reflection.nim
+++ b/src/library/Reflection.nim
@@ -79,7 +79,7 @@ proc defineModule*(moduleName: string) =
             ; 10
             
             print multiply.with: 6 5
-            ; 60
+            ; 30
         """:
             #=======================================================
             let val = popAttr(x.s)


### PR DESCRIPTION
multiply.with: 6 5
must be 30 not 60

# Description

The [attr](https://arturo-lang.io/latest/documentation/library/reflection/attr) example here is wrong.I fixed it

Fixes # (issue/s)

## Type of change

- [x] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (documentation-related additions)