### PR TITLE
[Paths\list] Use glob Pattern (Experiment)

### DIFF
--- a/src/library/Paths.nim
+++ b/src/library/Paths.nim
@@ -248,7 +248,7 @@ proc defineModule*(moduleName: string) =
                 elif relative:
                     contents = toSeq(walkDir(path, relative = true)).map((x) => x[1])
                 else:
-                    contents = toSeq(walkDirs(path))
+                    contents = toSeq(walkPattern(path))
 
                 push(newStringBlock(contents))
 


### PR DESCRIPTION
# Proposal

This PR proposes to be an experiment and list the limitations and breaking changes of this pattern when comparing to our old one.

- Related to #2161

## Experiment

```art
$> list "."                ; dot behavior (breaking change)
=> [arturo]

$> list ".."               ; double dot behavior (breaking change)
=> [Projects]

$> list "*.md"             ; Glob for extensions works fine
=> [AGENTS.md README.md]

$> list "*"                ; Glob all files works fine (same as our current `list "."`)
=> [.cache .config .git .gitattributes .github .gitignore .tokeignore .unitt AGENTS.md bin build.nims config.nims docs LICENSE README.md src test.art test.db tests tools unitt.toml version]

$> list "src"               ; Should list all files...
=> [src]

$> list "src/"              ; WTF?
=> []

$> list "src/*nim"          ; Works fine
=> [src\arturo.nim]

$> list "src/library/*nim"  ; Works fine
=> [src\library\Arithmetic.nim src\library\Bitwise.nim src\library\Collections.nim src\library\Colors.nim src\library\Comparison.nim src\library\Core.nim src\library\Crypto.nim src\library\Databases.nim src\library\Dates.nim src\library\Exceptions.nim src\library\Files.nim src\library\Io.nim src\library\Iterators.nim src\library\Logic.nim src\library\Net.nim src\library\Numbers.nim src\library\Paths.nim src\library\Quantities.nim src\library\Reflection.nim src\library\Sets.nim src\library\Sockets.nim src\library\Statistics.nim src\library\Strings.nim src\library\System.nim src\library\Types.nim src\library\Ui.nim]

$> list "src/*/*nim"        ; Should walk all directories and list all *nim files
=> []

$> list "**/*nim"           ; Should walk recursively and list all *nim files
=> []

$> list "*.nims"            ; Ok, we have *.nims files
=> [build.nims config.nims]

$> list "*.md"              ; Ok, we have *.md files
=> [AGENTS.md README.md]

$> list "*.{md,nims}"       ; Should list all *.md and *.nims files that we know they exists
=> []
```

## Notes

Tested on Windows 11, calling Arturo from Powershell.

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (documentation-related additions)