### PR TITLE
[UI\alert] Fix window handle assignment for notification icon on Windows

### DIFF
--- a/src/extras/pfd/pfd.cc
+++ b/src/extras/pfd/pfd.cc
@@ -1361,7 +1361,12 @@ inline notify::notify(std::string const &title,
 
     // For XP support
     nid->cbSize = NOTIFYICONDATAW_V2_SIZE;
-    nid->hWnd = nullptr;
+    nid->hWnd = ::GetConsoleWindow();
+
+    // Shell_NotifyIcon requires a valid window handle; fall back to the
+    // foreground window if the process has no console.
+    if (!nid->hWnd)
+        nid->hWnd = ::GetForegroundWindow();
     nid->uID = 0;
 
     // Flag Description:


### PR DESCRIPTION
# Description

<img width="690" height="159" alt="image" src="https://github.com/user-attachments/assets/ad025a53-0c71-4ef2-a8fe-39e37ea92632" />

Using console First.

Different cases (Using foreground first):

| `alert.info` | `alert.warning` | `alert.error` |
|--------------|-----------------|---------------|
|![](https://github.com/user-attachments/assets/e674eebd-7006-488b-accf-895de00188f7)|![](https://github.com/user-attachments/assets/2950629b-c59d-451a-a785-ec25485f47e9)|![](https://github.com/user-attachments/assets/ec54bf0c-0281-4847-8516-59341db007d5)|


Notifications attach now to a real window handle before calling `Shell_NotifyIcon`. This ensures `hWnd` won't be null.

https://learn.microsoft.com/en-us/windows/win32/api/shellapi/ns-shellapi-notifyicondataw

- Fixes #2134

## Type of change

- [ ] Code cleanup
- [ ] Unit tests (added or updated unit-tests)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (implementation update, or general performance enhancements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (documentation-related additions)