### PR TITLE
Add new skip-tests mode for CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
                 metadata: ${{ steps.version.outputs.VERSION }}
                 create_artifact: 'true'
                 artifact_version: ${{ steps.version.outputs.VERSION }}
- 
+
             - name: Check if tests should be skipped
               id: check_skip
               shell: bash


### PR DESCRIPTION
# Description

Tiny improvement. Basically, if the commit message contains `[skip tests]`, the CI workflow will work as usual, but will omit the last step (= run the unit-tests), e.g. in the case where we quickly want to check if it builds fine (but don't expect anything new re: unit-tests and their validity)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
