### PR TITLE
When evaluating code directly, we should show all errors properly

### DIFF
--- a/src/vm/errors.nim
+++ b/src/vm/errors.nim
@@ -42,8 +42,8 @@
 #=======================================
 
 when not defined(WEB):
-    import re, terminal
-import os, sequtils, strformat, strutils, sugar, std/with
+    import os, re, terminal
+import sequtils, strformat, strutils, sugar, std/with
 
 import helpers/strings
 import helpers/terminal
@@ -185,7 +185,7 @@ proc printErrorMessage(e: VError) =
     printError strip(indent(dedent(formatMessage(e.msg)), 2), chars={'\n'})
 
 proc printCodePreview(e: VError) =
-    when (not defined(NOERRORLINES)) and (not defined(BUNDLE)):
+    when (not defined(NOERRORLINES)) and (not defined(BUNDLE)) and (not defined(WEB)):
         if (not IsRepl) and (e.kind != CmdlineErr) and (e.kind != ProgramErr) :
             if e.context.file == "":
                 e.context.line = CurrentLine

--- a/src/vm/errors.nim
+++ b/src/vm/errors.nim
@@ -43,7 +43,7 @@
 
 when not defined(WEB):
     import re, terminal
-import sequtils, strformat, strutils, sugar, std/with
+import os, sequtils, strformat, strutils, sugar, std/with
 
 import helpers/strings
 import helpers/terminal
@@ -193,7 +193,10 @@ proc printCodePreview(e: VError) =
                     e.context.file = pcf.path
                 else:
                     e.context.file = currentFrame().path
-                
+
+            if e.context.file == "" or not fileExists(e.context.file):
+                return
+
             printError ""
             let fileContent = readFile(e.context.file)
             let codeLines = fileContent.splitLines()


### PR DESCRIPTION
# Description

The main reason of the crash is that in direct (`-e`) evaluation, there is no code file and thus we shouldn't show any code preview at all.

Fixes #2018 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
