### PR TITLE
Improve function scope performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,8 @@ jobs:
             - if: env.arturoCanRun == 'true' && steps.check_skip.outputs.skip != 'true'
               name: Run tests
               run: |
-                cd $GITHUB_WORKSPACE/arturo 
-                git clone https://github.com/arturo-lang/examples.git examples
+                cd $GITHUB_WORKSPACE/arturo
+                git clone https://github.com/arturo-lang/examples.git ../examples
 
                 arturo -v
                 if ! arturo tools/tester.art; then

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -353,7 +353,6 @@ proc execFunction*(fun: Value, fid: Hash) =
     ##   abide by this rule
 
     var memoizedParams: Value = nil
-    var savedSyms: SymTable
 
     let argsL = len(fun.params)
 
@@ -376,8 +375,9 @@ proc execFunction*(fun: Value, fid: Hash) =
             popN argsL
             push memd
             return
-        
-    savedSyms = Syms
+
+    pushScopeFrame()
+
     if not fun.imports.isNil:
         for k,v in pairs(fun.imports.d):
             SetSym(k, v)
@@ -406,12 +406,26 @@ proc execFunction*(fun: Value, fid: Hash) =
         if fun.memoize:
             setMemoized(fid, memoizedParams, stack.peek(0))
 
-        if not fun.exports.isNil:
-            for k in fun.exports.a:
-                if (let newSym = Syms.getOrDefault(k.s, nil); not newSym.isNil):
-                    savedSyms[k.s] = newSym
-        
-        Syms = savedSyms
+        var frame = popScopeFrame()
+        if fun.exports.isNil:
+            for k, prev in frame.pairs:
+                if prev.isNil:
+                    Syms.del(k)
+                else:
+                    Syms[k] = prev
+        else:
+            for k, prev in frame.pairs:
+                var isExport = false
+                for ek in fun.exports.a:
+                    if ek.s == k:
+                        isExport = true
+                        break
+                if isExport: continue
+                if prev.isNil:
+                    Syms.del(k)
+                else:
+                    Syms[k] = prev
+        releaseScopeFrame(frame)
 
 proc execFunctionInline*(fun: Value, fid: Hash) =
     ## Execute given Function value without scoping
@@ -484,14 +498,12 @@ proc execMethod*(meth: Value, fid: Hash) =
     ## - Symbols re-assigned inside will NOT 
     ##   overwrite the value in the outer scope
 
-    var savedSyms: SymTable
-
-    savedSyms = Syms
-
     when not defined(WEB):
         var fpath: ref string
         if (fpath = meth.info.path; not fpath.isNil()):
             pushFrame(fpath[], fromFile=true)
+
+    pushScopeFrame()
 
     for arg in meth.mparams:
         # pop argument and set it
@@ -510,7 +522,13 @@ proc execMethod*(meth: Value, fid: Hash) =
         discard
 
     finally:
-        Syms = savedSyms
+        var frame = popScopeFrame()
+        for k, prev in frame.pairs:
+            if prev.isNil:
+                Syms.del(k)
+            else:
+                Syms[k] = prev
+        releaseScopeFrame(frame)
 
         when not defined(WEB):
             if not fpath.isNil():

--- a/src/vm/globals.nim
+++ b/src/vm/globals.nim
@@ -267,6 +267,7 @@ proc recordScopeWrite*(s: string) {.inline.} =
 
 template SetSym*(s: string, v: Value, safe: static bool = false, forceReadOnly: static bool = false): untyped =
     ## Sets symbol to given value in the symbol table
+    recordScopeWrite(s)
     when safe:
         # When doing it safely, also check if the value to be assigned is a read-only value
         # - if it is - we have to copy it first
@@ -282,6 +283,7 @@ template SetSym*(s: string, v: Value, safe: static bool = false, forceReadOnly: 
         Syms[s] = v
 
 template UnsetSym*(s: string): untyped =
+    recordScopeWrite(s)
     Syms.del(s)
 
 template SetDictSym*(s: string, v: Value, safe: static bool = false): untyped =

--- a/src/vm/globals.nim
+++ b/src/vm/globals.nim
@@ -252,10 +252,13 @@ proc popScopeFrame*(): SymTable {.inline.} =
     ## Pop the topmost scope frame
     result = ScopeStack.pop()
 
+const ScopeFramePoolMax = 64
+
 proc releaseScopeFrame*(frame: var SymTable) {.inline.} =
-    ## Hand a used frame back to the pool
-    frame.clear()
-    ScopeFramePool.add(frame)
+    ## Hand a used frame back to the pool - dropped if pool is full
+    if ScopeFramePool.len < ScopeFramePoolMax:
+        frame.clear()
+        ScopeFramePool.add(frame)
 
 proc recordScopeWrite*(s: string) {.inline.} =
     ## Record `s`'s previous value in the current scope frame,

--- a/src/vm/globals.nim
+++ b/src/vm/globals.nim
@@ -43,6 +43,14 @@ var
     # dictionary symbols stack
     DictSyms* {.global.}        : seq[ValueDict]            ## The stack of dictionaries to be filled
                                                             ## when using `execDictionary`
+
+    # function scope stack
+    ScopeStack* {.global.}      : seq[SymTable]                 ## Per-call undo log of touched
+                                                                ## symbols (nil = didn't exist)
+
+    # scope frame pool
+    ScopeFramePool* {.global.}  : seq[SymTable]                 ## Recycled frames, to avoid
+                                                                ## reallocating on every call
     
     # active stores
     Stores* {.global.}          : seq[VStore]               ## The list of active stores to be stored
@@ -232,6 +240,30 @@ template GetSym*(s: string): untyped =
     ## **Hint:** if the key doesn't exist, it will throw an error;
     ## so, we have to make sure we know it exists beforehand
     Syms[s]
+
+proc pushScopeFrame*() {.inline.} =
+    ## Push a fresh - or recycled - scope frame
+    if ScopeFramePool.len > 0:
+        ScopeStack.add(ScopeFramePool.pop())
+    else:
+        ScopeStack.add(initTable[string, Value](initialSize = 4))
+
+proc popScopeFrame*(): SymTable {.inline.} =
+    ## Pop the topmost scope frame
+    result = ScopeStack.pop()
+
+proc releaseScopeFrame*(frame: var SymTable) {.inline.} =
+    ## Hand a used frame back to the pool
+    frame.clear()
+    ScopeFramePool.add(frame)
+
+proc recordScopeWrite*(s: string) {.inline.} =
+    ## Record `s`'s previous value in the current scope frame,
+    ## the first time it's touched - nil if it didn't exist
+    if ScopeStack.len > 0:
+        let frame = addr ScopeStack[^1]
+        if not frame[].hasKey(s):
+            frame[][s] = Syms.getOrDefault(s, nil)
 
 template SetSym*(s: string, v: Value, safe: static bool = false, forceReadOnly: static bool = false): untyped =
     ## Sets symbol to given value in the symbol table

--- a/tools/tester.art
+++ b/tools/tester.art
@@ -170,7 +170,7 @@ print color #gray ~"  Release: @|sys\release|\n"
 supertime: in's benchmark.get [
     runSet "Unit Tests" "../tests/unittests"
     ;runSet "Errors" "../tests/errors"
-    runSet "Examples" "../examples/src/rosetta"
+    runSet "Examples" "../../examples/src/rosetta"
 ]
 
 if supersuccess < supertotal-errorMargin [


### PR DESCRIPTION
# Description

This PR aims to improve non-inline function call speed. The main logic: 

- instead of cloning the entire Syms table on every call (and replacing it back on exit), we now push a small per-call frame that records (= lazily, only on first write) the previous value of any symbol the function actually touches

- on exit, we simple "replay" that frame in reverse, deleting symbols that didn't exist before the call and restoring the rest, while letting anything in `.exports:` leak through. 

- frames come from a small pool so we don't allocate on every call

The main effect of all this is to significantly decrease the cost per function call and - per my calculations - have a speed gain of ~30%. (Here, on my '18 MacBook at least, the benchmarks when running the main test suite (@ tools/tester.art) have consistently shown a drop from ~230s to 160s) 🚀 

## Type of change

- [x] Enhancement (implementation update, or general performance enhancements)
