### PR TITLE
Improve arithmetic operations

### DIFF
--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -744,7 +744,7 @@ proc ExecLoop*(cnst: ValueArray, it: VBinary) =
                 of opNeg                : arithmeticFastpathA(DoNeg, normalIntegerNeg)
 
                 # increment/decrement
-                of opInc                : DoInc()
+                of opInc                : arithmeticFastpathA(DoInc, normalIntegerInc)
                 of opDec                : DoDec()
 
                 # binary operators

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -735,7 +735,7 @@ proc ExecLoop*(cnst: ValueArray, it: VBinary) =
                 # arithmetic operators
                 of opAdd                : arithmeticFastpathB(DoAdd, normalIntegerAdd)
                 of opSub                : arithmeticFastpathB(DoSub, normalIntegerSub)
-                of opMul                : DoMul()
+                of opMul                : arithmeticFastpathB(DoMul, normalIntegerMul)
                 of opDiv                : DoDiv()
                 of opFdiv               : DoFdiv()
                 of opMod                : DoMod()

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -736,7 +736,7 @@ proc ExecLoop*(cnst: ValueArray, it: VBinary) =
                 of opAdd                : arithmeticFastpathB(DoAdd, normalIntegerAdd)
                 of opSub                : arithmeticFastpathB(DoSub, normalIntegerSub)
                 of opMul                : arithmeticFastpathB(DoMul, normalIntegerMul)
-                of opDiv                : DoDiv()
+                of opDiv                : arithmeticFastpathB(DoDiv, normalIntegerDiv)
                 of opFdiv               : DoFdiv()
                 of opMod                : DoMod()
                 of opPow                : DoPow()

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -741,7 +741,7 @@ proc ExecLoop*(cnst: ValueArray, it: VBinary) =
                 of opMod                : arithmeticFastpathB(DoMod, normalIntegerMod)
                 of opPow                : arithmeticFastpathB(DoPow, normalIntegerPow)
 
-                of opNeg                : DoNeg()
+                of opNeg                : arithmeticFastpathA(DoNeg, normalIntegerNeg)
 
                 # increment/decrement
                 of opInc                : DoInc()

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -42,6 +42,7 @@ when not defined(WEB):
 import vm/values/custom/[vbinary]
 
 import vm/values/comparison
+import vm/values/operators
 
 #=======================================
 # Types
@@ -732,7 +733,7 @@ proc ExecLoop*(cnst: ValueArray, it: VBinary) =
 
                 # [0x80-0x8F]
                 # arithmetic operators
-                of opAdd                : DoAdd()
+                of opAdd                : arithmeticFastpathB(DoAdd, normalIntegerAdd)
                 of opSub                : DoSub()
                 of opMul                : DoMul()
                 of opDiv                : DoDiv()

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -745,7 +745,7 @@ proc ExecLoop*(cnst: ValueArray, it: VBinary) =
 
                 # increment/decrement
                 of opInc                : arithmeticFastpathA(DoInc, normalIntegerInc)
-                of opDec                : DoDec()
+                of opDec                : arithmeticFastpathA(DoDec, normalIntegerDec)
 
                 # binary operators
                 of opBNot               : DoBNot()

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -737,7 +737,7 @@ proc ExecLoop*(cnst: ValueArray, it: VBinary) =
                 of opSub                : arithmeticFastpathB(DoSub, normalIntegerSub)
                 of opMul                : arithmeticFastpathB(DoMul, normalIntegerMul)
                 of opDiv                : arithmeticFastpathB(DoDiv, normalIntegerDiv)
-                of opFdiv               : DoFdiv()
+                of opFdiv               : arithmeticFastpathB(DoFdiv, normalIntegerFDiv)
                 of opMod                : DoMod()
                 of opPow                : DoPow()
 

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -734,7 +734,7 @@ proc ExecLoop*(cnst: ValueArray, it: VBinary) =
                 # [0x80-0x8F]
                 # arithmetic operators
                 of opAdd                : arithmeticFastpathB(DoAdd, normalIntegerAdd)
-                of opSub                : DoSub()
+                of opSub                : arithmeticFastpathB(DoSub, normalIntegerSub)
                 of opMul                : DoMul()
                 of opDiv                : DoDiv()
                 of opFdiv               : DoFdiv()

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -739,7 +739,7 @@ proc ExecLoop*(cnst: ValueArray, it: VBinary) =
                 of opDiv                : arithmeticFastpathB(DoDiv, normalIntegerDiv)
                 of opFdiv               : arithmeticFastpathB(DoFdiv, normalIntegerFDiv)
                 of opMod                : arithmeticFastpathB(DoMod, normalIntegerMod)
-                of opPow                : DoPow()
+                of opPow                : arithmeticFastpathB(DoPow, normalIntegerPow)
 
                 of opNeg                : DoNeg()
 

--- a/src/vm/exec.nim
+++ b/src/vm/exec.nim
@@ -738,7 +738,7 @@ proc ExecLoop*(cnst: ValueArray, it: VBinary) =
                 of opMul                : arithmeticFastpathB(DoMul, normalIntegerMul)
                 of opDiv                : arithmeticFastpathB(DoDiv, normalIntegerDiv)
                 of opFdiv               : arithmeticFastpathB(DoFdiv, normalIntegerFDiv)
-                of opMod                : DoMod()
+                of opMod                : arithmeticFastpathB(DoMod, normalIntegerMod)
                 of opPow                : DoPow()
 
                 of opNeg                : DoNeg()

--- a/src/vm/values/operators.nim
+++ b/src/vm/values/operators.nim
@@ -477,7 +477,10 @@ template normalIntegerShrI*(x: var Value, y: int): untyped =
 template arithmeticFastpathA*(slowOp, intFastFn: untyped): untyped =
     ## inline fast-path for unary arithmetic ops on a NormalInteger operand -
     ## on any other operand kind, it defaults to the normal ``slowOp``.
-    if likely(stack.sTop().kind == Integer) and likely(stack.sTop().iKind == NormalInteger):
+    ## The kind+iKind check is fused into a single bitwise compare so the
+    ## compiler emits one branch instead of one per ``likely(...)`` clause.
+    let xv {.cursor.} = stack.sTop()
+    if likely(((ord(xv.kind) xor ord(Integer)) or ord(xv.iKind)) == 0):
         let x = stack.pop()
         stack.push(intFastFn(x.i))
     else:
@@ -486,8 +489,11 @@ template arithmeticFastpathA*(slowOp, intFastFn: untyped): untyped =
 template arithmeticFastpathB*(slowOp, intFastFn: untyped): untyped =
     ## inline fast-path for binary arithmetic ops on two NormalInteger operands -
     ## on any other operand kind, it defaults to the normal ``slowOp``
-    if likely(stack.peek(0).kind == Integer) and likely(stack.peek(1).kind == Integer) and
-       likely(stack.peek(0).iKind == NormalInteger) and likely(stack.peek(1).iKind == NormalInteger):
+    let xv {.cursor.} = stack.peek(0)
+    let yv {.cursor.} = stack.peek(1)
+    if likely(((ord(xv.kind) xor ord(Integer)) or
+               (ord(yv.kind) xor ord(Integer)) or
+               ord(xv.iKind) or ord(yv.iKind)) == 0):
         let x = stack.pop()
         let y = stack.pop()
         stack.push(intFastFn(x.i, y.i))

--- a/src/vm/values/operators.nim
+++ b/src/vm/values/operators.nim
@@ -477,8 +477,6 @@ template normalIntegerShrI*(x: var Value, y: int): untyped =
 template arithmeticFastpathA*(slowOp, intFastFn: untyped): untyped =
     ## inline fast-path for unary arithmetic ops on a NormalInteger operand -
     ## on any other operand kind, it defaults to the normal ``slowOp``.
-    ## The kind+iKind check is fused into a single bitwise compare so the
-    ## compiler emits one branch instead of one per ``likely(...)`` clause.
     let xv {.cursor.} = stack.sTop()
     if likely(((ord(xv.kind) xor ord(Integer)) or ord(xv.iKind)) == 0):
         let x = stack.pop()

--- a/src/vm/values/operators.nim
+++ b/src/vm/values/operators.nim
@@ -462,6 +462,29 @@ template normalIntegerShrI*(x: var Value, y: int): untyped =
     ## and set result in-place
     x.i = x.i shr y
 
+template arithmeticFastpathA*(slowOp, intFastFn: untyped): untyped =
+    ## Inline fast-path for unary arithmetic ops on a NormalInteger operand.
+    ## On any other operand kind (Literal, BigInteger, Floating, ...) it
+    ## falls through to the full builtin closure ``slowOp``.
+    if likely(stack.sTop().kind == Integer) and likely(stack.sTop().iKind == NormalInteger):
+        let x = stack.pop()
+        stack.push(intFastFn(x.i))
+    else:
+        slowOp()
+
+template arithmeticFastpathB*(slowOp, intFastFn: untyped): untyped =
+    ## Inline fast-path for binary arithmetic ops on two NormalInteger operands.
+    ## Falls through to ``slowOp`` for any other case.
+    ## Stack convention: top-of-stack is the *first* operand (``x``), matching
+    ## ``require`` in vm/checks.nim — non-commutative ops would otherwise swap.
+    if likely(stack.peek(0).kind == Integer) and likely(stack.peek(1).kind == Integer) and
+       likely(stack.peek(0).iKind == NormalInteger) and likely(stack.peek(1).iKind == NormalInteger):
+        let x = stack.pop()
+        let y = stack.pop()
+        stack.push(intFastFn(x.i, y.i))
+    else:
+        slowOp()
+
 template objectOperationOrNothing*(operation: string, mgkMeth: MagicMethod, oneparam: static bool = false, inplace: static bool = false): untyped =
     if x.kind == Object and x.magic.fetch(mgkMeth):
         when inplace:

--- a/src/vm/values/operators.nim
+++ b/src/vm/values/operators.nim
@@ -175,6 +175,12 @@ template invalidOperation(op: string): untyped =
 
 template normalIntegerOperation*(inPlace=false): bool =
     ## check if both operands (x,y) are Integers, but not GMP-style BigNums
+    ##
+    ## The check is expressed as a single bitwise OR against zero so the
+    ## compiler emits one branch instead of one per ``likely(...)`` clause.
+    ## Relies on ``ord(NormalInteger) == 0`` and on the fact that reading
+    ## ``iKind`` of a non-Integer Value is harmless in release builds (same
+    ## pattern used by ``getValuePair`` in vm/values/types.nim).
     when inPlace:
         let xKind {.inject.} = InPlaced.kind
         when declared(y):
@@ -187,14 +193,20 @@ template normalIntegerOperation*(inPlace=false): bool =
 
     when inPlace:
         when declared(y):
-            likely(xKind==Integer) and likely(InPlaced.iKind==NormalInteger) and likely(yKind==Integer) and likely(y.iKind==NormalInteger)
+            likely(((ord(xKind) xor ord(Integer)) or
+                    (ord(yKind) xor ord(Integer)) or
+                    ord(InPlaced.iKind) or ord(y.iKind)) == 0)
         else:
-            likely(xKind==Integer) and likely(InPlaced.iKind==NormalInteger)
+            likely(((ord(xKind) xor ord(Integer)) or
+                    ord(InPlaced.iKind)) == 0)
     else:
         when declared(y):
-            likely(xKind==Integer) and likely(x.iKind==NormalInteger) and likely(yKind==Integer) and likely(y.iKind==NormalInteger)
+            likely(((ord(xKind) xor ord(Integer)) or
+                    (ord(yKind) xor ord(Integer)) or
+                    ord(x.iKind) or ord(y.iKind)) == 0)
         else:
-            likely(xKind==Integer) and likely(x.iKind==NormalInteger)
+            likely(((ord(xKind) xor ord(Integer)) or
+                    ord(x.iKind)) == 0)
 
 template normalIntegerAdd*(x, y: int): untyped =
     ## add two normal Integer values, checking for overflow

--- a/src/vm/values/operators.nim
+++ b/src/vm/values/operators.nim
@@ -463,9 +463,8 @@ template normalIntegerShrI*(x: var Value, y: int): untyped =
     x.i = x.i shr y
 
 template arithmeticFastpathA*(slowOp, intFastFn: untyped): untyped =
-    ## Inline fast-path for unary arithmetic ops on a NormalInteger operand.
-    ## On any other operand kind (Literal, BigInteger, Floating, ...) it
-    ## falls through to the full builtin closure ``slowOp``.
+    ## inline fast-path for unary arithmetic ops on a NormalInteger operand.
+    ## on any other operand kind, it defaults to the normal ``slowOp``.
     if likely(stack.sTop().kind == Integer) and likely(stack.sTop().iKind == NormalInteger):
         let x = stack.pop()
         stack.push(intFastFn(x.i))
@@ -473,10 +472,8 @@ template arithmeticFastpathA*(slowOp, intFastFn: untyped): untyped =
         slowOp()
 
 template arithmeticFastpathB*(slowOp, intFastFn: untyped): untyped =
-    ## Inline fast-path for binary arithmetic ops on two NormalInteger operands.
-    ## Falls through to ``slowOp`` for any other case.
-    ## Stack convention: top-of-stack is the *first* operand (``x``), matching
-    ## ``require`` in vm/checks.nim — non-commutative ops would otherwise swap.
+    ## inline fast-path for binary arithmetic ops on two NormalInteger operands.
+    ## on any other operand kind, it defaults to the normal ``slowOp``.
     if likely(stack.peek(0).kind == Integer) and likely(stack.peek(1).kind == Integer) and
        likely(stack.peek(0).iKind == NormalInteger) and likely(stack.peek(1).iKind == NormalInteger):
         let x = stack.pop()

--- a/src/vm/values/operators.nim
+++ b/src/vm/values/operators.nim
@@ -174,13 +174,8 @@ template invalidOperation(op: string): untyped =
 #=======================================
 
 template normalIntegerOperation*(inPlace=false): bool =
-    ## check if both operands (x,y) are Integers, but not GMP-style BigNums
-    ##
-    ## The check is expressed as a single bitwise OR against zero so the
-    ## compiler emits one branch instead of one per ``likely(...)`` clause.
-    ## Relies on ``ord(NormalInteger) == 0`` and on the fact that reading
-    ## ``iKind`` of a non-Integer Value is harmless in release builds (same
-    ## pattern used by ``getValuePair`` in vm/values/types.nim).
+    ## check if both operands (x,y) are Integers, 
+    ## but not GMP-style BigNums
     when inPlace:
         let xKind {.inject.} = InPlaced.kind
         when declared(y):
@@ -191,6 +186,9 @@ template normalIntegerOperation*(inPlace=false): bool =
             when declared(y):
                 let yKind {.inject.} = y.kind
 
+    ## Relies on ``ord(NormalInteger) == 0`` and on the fact that reading
+    ## ``iKind`` of a non-Integer Value is harmless
+    ## (similar to pattern used by ``getValuePair``)
     when inPlace:
         when declared(y):
             likely(((ord(xKind) xor ord(Integer)) or

--- a/src/vm/values/operators.nim
+++ b/src/vm/values/operators.nim
@@ -463,7 +463,7 @@ template normalIntegerShrI*(x: var Value, y: int): untyped =
     x.i = x.i shr y
 
 template arithmeticFastpathA*(slowOp, intFastFn: untyped): untyped =
-    ## inline fast-path for unary arithmetic ops on a NormalInteger operand.
+    ## inline fast-path for unary arithmetic ops on a NormalInteger operand -
     ## on any other operand kind, it defaults to the normal ``slowOp``.
     if likely(stack.sTop().kind == Integer) and likely(stack.sTop().iKind == NormalInteger):
         let x = stack.pop()
@@ -472,8 +472,8 @@ template arithmeticFastpathA*(slowOp, intFastFn: untyped): untyped =
         slowOp()
 
 template arithmeticFastpathB*(slowOp, intFastFn: untyped): untyped =
-    ## inline fast-path for binary arithmetic ops on two NormalInteger operands.
-    ## on any other operand kind, it defaults to the normal ``slowOp``.
+    ## inline fast-path for binary arithmetic ops on two NormalInteger operands -
+    ## on any other operand kind, it defaults to the normal ``slowOp``
     if likely(stack.peek(0).kind == Integer) and likely(stack.peek(1).kind == Integer) and
        likely(stack.peek(0).iKind == NormalInteger) and likely(stack.peek(1).iKind == NormalInteger):
         let x = stack.pop()


### PR DESCRIPTION
# Description

Right now, all arithmetic operations related opCode (`opAdd`, `opSub`, etc) go through the main pipeline:

- exec loop
- call to closure
- stdlib implementation (with `generateOperationA`/`generateOperationB` that trigger the corresponding branching & operations)

The idea of this PR is very simple: since most arithmetic operations are between normal (= non-bigint) integer, why not include a "fast path" inside the exec loop itself and only resort to the normal call, if that fails?

Per my calculations, the average performance gain is ~5%, while in integer-heavy operations, this can go up to 10%.

## Type of change

- [x] Enhancement (implementation update, or general performance enhancements)
