### PR TITLE
Add better (and more consistent) HTML/XML parsing capabilities

### DIFF
--- a/src/extras/htmlparser/htmlparser.nim
+++ b/src/extras/htmlparser/htmlparser.nim
@@ -2020,10 +2020,15 @@ proc parseHtml*(s: Stream, filename: string,
   open(x, s, filename, {reportComments, reportWhitespace, allowUnquotedAttribs,
     allowEmptyAttribs})
   next(x)
-  # skip the DOCTYPE:
-  if x.kind == xmlSpecial: next(x)
+  # capture the DOCTYPE (if any) so callers can preserve it:
+  var doctypeContent = ""
+  if x.kind == xmlSpecial:
+    doctypeContent = x.rawData
+    next(x)
 
   result = newElement("document")
+  if doctypeContent.len > 0:
+    result.attrs = {"_doctype": doctypeContent}.toXmlAttributes
   result.addNode(parse(x, errors))
   #if x.kind != xmlEof:
   #  adderr(errorMsg(x, "EOF expected"))
@@ -2034,7 +2039,7 @@ proc parseHtml*(s: Stream, filename: string,
       # force progress!
       next(x)
   close(x)
-  if result.len == 1:
+  if result.len == 1 and doctypeContent.len == 0:
     result = result[0]
 
 proc parseHtml*(s: Stream): XmlNode =

--- a/src/helpers/html.nim
+++ b/src/helpers/html.nim
@@ -21,27 +21,33 @@ import vm/values/value
 #=======================================
 
 when defined(PARSERS):
-    # TODO(Helpers/xml) re-implement HTML parsing?
-    #  Same as with `parseXMLNode`: we first have to define what this means. Basically, what would an HTML-parsing function normally yield? How are children/nodes/attributes supposed to fit in Arturo's value system: arrays, dictionaries, scalars, etc?
-    #  labels: helpers, library, enhancement, bug, open discussion
     proc parseHtmlNode(node: XmlNode): Value =
         result = newDictionary()
-        if node.kind()==xnElement:
-            result.d["attrs"] = newDictionary()
-            if node.attrsLen() > 0:
-                for k,v in pairs(node.attrs()):
-                    result.d["attrs"].d[k] = newString(v)
-
-            result.d["text"] = newString(node.innerText())
-            for subnode in items(node):
-                if subnode.kind()==xnElement:
-                    if result.d.hasKey(subnode.tag()) and result.d[subnode.tag()].kind==Dictionary:
-                        result.d[subnode.tag()] = newBlock(@[result.d[subnode.tag()]])
-
-                    if result.d.hasKey(subnode.tag()):
-                        result.d[subnode.tag()].a.add(parseHtmlNode(subnode))
-                    else:
-                        result.d[subnode.tag()] = parseHtmlNode(subnode)
+        case node.kind:
+            of xnElement:
+                result.d["kind"] = newLiteral("element")
+                result.d["tag"] = newString(node.tag())
+                let attrsDict = newDictionary()
+                if node.attrsLen() > 0:
+                    for k, v in pairs(node.attrs()):
+                        attrsDict.d[k] = newString(v)
+                result.d["attrs"] = attrsDict
+                var children = newBlock()
+                for sub in items(node):
+                    children.a.add(parseHtmlNode(sub))
+                result.d["children"] = children
+            of xnText, xnVerbatimText:
+                result.d["kind"] = newLiteral("text")
+                result.d["value"] = newString(node.text)
+            of xnComment:
+                result.d["kind"] = newLiteral("comment")
+                result.d["value"] = newString(node.text)
+            of xnCData:
+                result.d["kind"] = newLiteral("cdata")
+                result.d["value"] = newString(node.text)
+            of xnEntity:
+                result.d["kind"] = newLiteral("entity")
+                result.d["value"] = newString(node.text)
 
     proc parseHtmlInput*(input: string): Value =
         parseHtmlNode(parseHtml(input)).d["html"]

--- a/src/helpers/html.nim
+++ b/src/helpers/html.nim
@@ -21,6 +21,21 @@ import vm/values/value
 #=======================================
 
 when defined(PARSERS):
+    # TODO(Helpers/html) consider replacing the underlying HTML parser with lexbor
+    #  The current parser (vendored from Nim's stdlib at `extras/htmlparser`) is
+    #  SGML/XML-ish, not HTML5-spec. It handles cleanish HTML fine but struggles
+    #  with worst tag soup: unclosed `<li>` cascades, `<script>` raw-text edge
+    #  cases, foreign content (inline SVG/MathML), implicit `<tbody>`, etc.
+    #
+    #  For real-web HTML5 parity, a future option is to vendor lexbor (C, ~600KB
+    #  static lib for the HTML+DOM subset, no external deps, very fast) under
+    #  `extras/lexbor/` and expose a drop-in `parseHtml` returning the same
+    #  XmlNode shape, gated behind a `--define:LEXBOR` build flag. The Arturo
+    #  tree shape produced by `parseHtmlInput` would not change, so external
+    #  packages built on `read.html` would gain HTML5 conformance transparently.
+    #
+    #  Alternative: gumbo (Google's HTML5 parser; archived since 2016 but works).
+    #  labels: helpers, library, enhancement, open discussion
     proc unescapeHtmlEntities*(s: string): string =
         result = newStringOfCap(s.len)
         var i = 0

--- a/src/helpers/html.nim
+++ b/src/helpers/html.nim
@@ -55,6 +55,11 @@ when defined(PARSERS):
         result.d["kind"] = newLiteral("document")
         var children = newBlock()
         if root.kind == xnElement and root.tag == "document":
+            if root.attrsLen() > 0 and root.attrs().hasKey("_doctype"):
+                let dt = newDictionary()
+                dt.d["kind"] = newLiteral("doctype")
+                dt.d["value"] = newString(root.attrs()["_doctype"])
+                children.a.add(dt)
             for sub in items(root):
                 children.a.add(parseHtmlNode(sub))
         else:

--- a/src/helpers/html.nim
+++ b/src/helpers/html.nim
@@ -21,36 +21,6 @@ import vm/values/value
 #=======================================
 
 when defined(PARSERS):
-    proc unescapeXmlEntities*(s: string): string =
-        result = newStringOfCap(s.len)
-        var i = 0
-        while i < s.len:
-            if s[i] == '&':
-                var j = i + 1
-                while j < s.len and j - i < 12 and s[j] != ';':
-                    inc j
-                if j < s.len and s[j] == ';' and j > i + 1:
-                    let body = s[i+1 ..< j]
-                    var decoded = ""
-                    case body:
-                        of "amp":  decoded = "&"
-                        of "lt":   decoded = "<"
-                        of "gt":   decoded = ">"
-                        of "quot": decoded = "\""
-                        of "apos": decoded = "'"
-                        else:
-                            if body.len > 1 and body[0] == '#':
-                                decoded = entityToUtf8(body)
-                    if decoded.len > 0:
-                        result.add(decoded)
-                        i = j + 1
-                        continue
-                result.add('&')
-                inc i
-            else:
-                result.add(s[i])
-                inc i
-
     proc unescapeHtmlEntities*(s: string): string =
         result = newStringOfCap(s.len)
         var i = 0

--- a/src/helpers/html.nim
+++ b/src/helpers/html.nim
@@ -21,6 +21,36 @@ import vm/values/value
 #=======================================
 
 when defined(PARSERS):
+    proc unescapeXmlEntities*(s: string): string =
+        result = newStringOfCap(s.len)
+        var i = 0
+        while i < s.len:
+            if s[i] == '&':
+                var j = i + 1
+                while j < s.len and j - i < 12 and s[j] != ';':
+                    inc j
+                if j < s.len and s[j] == ';' and j > i + 1:
+                    let body = s[i+1 ..< j]
+                    var decoded = ""
+                    case body:
+                        of "amp":  decoded = "&"
+                        of "lt":   decoded = "<"
+                        of "gt":   decoded = ">"
+                        of "quot": decoded = "\""
+                        of "apos": decoded = "'"
+                        else:
+                            if body.len > 1 and body[0] == '#':
+                                decoded = entityToUtf8(body)
+                    if decoded.len > 0:
+                        result.add(decoded)
+                        i = j + 1
+                        continue
+                result.add('&')
+                inc i
+            else:
+                result.add(s[i])
+                inc i
+
     proc unescapeHtmlEntities*(s: string): string =
         result = newStringOfCap(s.len)
         var i = 0

--- a/src/helpers/html.nim
+++ b/src/helpers/html.nim
@@ -21,6 +21,26 @@ import vm/values/value
 #=======================================
 
 when defined(PARSERS):
+    proc unescapeHtmlEntities*(s: string): string =
+        result = newStringOfCap(s.len)
+        var i = 0
+        while i < s.len:
+            if s[i] == '&':
+                var j = i + 1
+                while j < s.len and j - i < 12 and s[j] != ';':
+                    inc j
+                if j < s.len and s[j] == ';' and j > i + 1:
+                    let decoded = entityToUtf8(s[i+1 ..< j])
+                    if decoded.len > 0:
+                        result.add(decoded)
+                        i = j + 1
+                        continue
+                result.add('&')
+                inc i
+            else:
+                result.add(s[i])
+                inc i
+
     proc parseHtmlNode(node: XmlNode): Value =
         result = newDictionary()
         case node.kind:

--- a/src/helpers/html.nim
+++ b/src/helpers/html.nim
@@ -50,4 +50,13 @@ when defined(PARSERS):
                 result.d["value"] = newString(node.text)
 
     proc parseHtmlInput*(input: string): Value =
-        parseHtmlNode(parseHtml(input)).d["html"]
+        let root = parseHtml(input)
+        result = newDictionary()
+        result.d["kind"] = newLiteral("document")
+        var children = newBlock()
+        if root.kind == xnElement and root.tag == "document":
+            for sub in items(root):
+                children.a.add(parseHtmlNode(sub))
+        else:
+            children.a.add(parseHtmlNode(root))
+        result.d["children"] = children

--- a/src/helpers/html.nim
+++ b/src/helpers/html.nim
@@ -3,8 +3,18 @@
 # Programming Language + Bytecode VM compiler
 # (c) 2019-2026 Yanis Zafirópulos
 #
-# @file: helpers/csv.nim
+# @file: helpers/html.nim
 #=======================================================
+
+# TODO(Helpers/html) Replace underlying HTML parser?
+#  The current parser (vendored from Nim's stdlib at `extras/htmlparser`) doesn't 
+#  really conform to the HTML5 spec. It handles clean HTML just fine but could struggle
+#  with missing closing tags, etc
+#
+#  What we could do is look into different options (e.g. lexbor @ https://github.com/lexbor/lexbor)
+#
+#  Another alternative: gumbo (https://codeberg.org/gumbo-parser/gumbo-parser).
+#  labels: helpers, library, enhancement
 
 #=======================================
 # Libraries
@@ -21,21 +31,6 @@ import vm/values/value
 #=======================================
 
 when defined(PARSERS):
-    # TODO(Helpers/html) consider replacing the underlying HTML parser with lexbor
-    #  The current parser (vendored from Nim's stdlib at `extras/htmlparser`) is
-    #  SGML/XML-ish, not HTML5-spec. It handles cleanish HTML fine but struggles
-    #  with worst tag soup: unclosed `<li>` cascades, `<script>` raw-text edge
-    #  cases, foreign content (inline SVG/MathML), implicit `<tbody>`, etc.
-    #
-    #  For real-web HTML5 parity, a future option is to vendor lexbor (C, ~600KB
-    #  static lib for the HTML+DOM subset, no external deps, very fast) under
-    #  `extras/lexbor/` and expose a drop-in `parseHtml` returning the same
-    #  XmlNode shape, gated behind a `--define:LEXBOR` build flag. The Arturo
-    #  tree shape produced by `parseHtmlInput` would not change, so external
-    #  packages built on `read.html` would gain HTML5 conformance transparently.
-    #
-    #  Alternative: gumbo (Google's HTML5 parser; archived since 2016 but works).
-    #  labels: helpers, library, enhancement, open discussion
     proc unescapeHtmlEntities*(s: string): string =
         result = newStringOfCap(s.len)
         var i = 0

--- a/src/helpers/xml.nim
+++ b/src/helpers/xml.nim
@@ -12,7 +12,7 @@
 
 
 when defined(PARSERS):
-    import sequtils, strtabs, sugar
+    import strtabs
     import tables, xmlparser, xmltree
 
 import vm/values/value
@@ -22,34 +22,38 @@ import vm/values/value
 #=======================================
 
 when defined(PARSERS):
-    # TODO(Helpers/xml) re-implement XML parsing
-    #  This `parseXMLNode` supposedly "works", but we first have to define what this means: basically, what would an XML-parsing function normally yield? How are children/nodes/attributes supposed to fit in Arturo's value system: arrays, dictionaries, scalars, etc?
-    #  labels: helpers, library, enhancement, bug, open discussion
-    proc parseXMLNode*(n: XmlNode, level: int = 0): Value =
-        let items = toSeq(n.items)
-        if items.len == 1 and items[0].kind == xnText:
-            return newString(items[0].text)
-
-        var children = newBlock()
+    proc parseXMLNode*(node: XmlNode): Value =
         result = newDictionary()
-        for child in n.items:
-            let subtags = toSeq(n.items).map((x) => x.tag)
-            if count(subtags, child.tag)>1:
-                children.a.add(parseXMLNode(child, level+1))
-            else:
-                result.d[child.tag] = parseXMLNode(child, level+1)
-
-        if n.attrsLen > 0:
-            result.d["_tag"] = newString(n.tag)
-            for k,v in n.attrs.pairs:
-                result.d[k] = newString(v)
-            if children.a.len > 0:
+        case node.kind:
+            of xnElement:
+                result.d["kind"] = newLiteral("element")
+                result.d["tag"] = newString(node.tag())
+                let attrsDict = newDictionary()
+                if node.attrsLen() > 0:
+                    for k, v in pairs(node.attrs()):
+                        attrsDict.d[k] = newString(v)
+                result.d["attrs"] = attrsDict
+                var children = newBlock()
+                for sub in items(node):
+                    children.a.add(parseXMLNode(sub))
                 result.d["children"] = children
-        else:
-            if result.d.len > 0:
-                result.d["children"] = children
-            else:
-                result = children
+            of xnText, xnVerbatimText:
+                result.d["kind"] = newLiteral("text")
+                result.d["value"] = newString(node.text)
+            of xnComment:
+                result.d["kind"] = newLiteral("comment")
+                result.d["value"] = newString(node.text)
+            of xnCData:
+                result.d["kind"] = newLiteral("cdata")
+                result.d["value"] = newString(node.text)
+            of xnEntity:
+                result.d["kind"] = newLiteral("entity")
+                result.d["value"] = newString(node.text)
 
     proc parseXMLInput*(input: string): Value =
-        parseXMLNode(parseXml(input))
+        let root = parseXml(input)
+        result = newDictionary()
+        result.d["kind"] = newLiteral("document")
+        var children = newBlock()
+        children.a.add(parseXMLNode(root))
+        result.d["children"] = children

--- a/src/helpers/xml.nim
+++ b/src/helpers/xml.nim
@@ -15,6 +15,8 @@ when defined(PARSERS):
     import strtabs
     import tables, xmlparser, xmltree
 
+    import extras/htmlparser
+
 import vm/values/value
 
 #=======================================
@@ -22,6 +24,36 @@ import vm/values/value
 #=======================================
 
 when defined(PARSERS):
+    proc unescapeXmlEntities*(s: string): string =
+        result = newStringOfCap(s.len)
+        var i = 0
+        while i < s.len:
+            if s[i] == '&':
+                var j = i + 1
+                while j < s.len and j - i < 12 and s[j] != ';':
+                    inc j
+                if j < s.len and s[j] == ';' and j > i + 1:
+                    let body = s[i+1 ..< j]
+                    var decoded = ""
+                    case body:
+                        of "amp":  decoded = "&"
+                        of "lt":   decoded = "<"
+                        of "gt":   decoded = ">"
+                        of "quot": decoded = "\""
+                        of "apos": decoded = "'"
+                        else:
+                            if body.len > 1 and body[0] == '#':
+                                decoded = entityToUtf8(body)
+                    if decoded.len > 0:
+                        result.add(decoded)
+                        i = j + 1
+                        continue
+                result.add('&')
+                inc i
+            else:
+                result.add(s[i])
+                inc i
+
     proc parseXMLNode*(node: XmlNode): Value =
         result = newDictionary()
         case node.kind:

--- a/src/helpers/xml.nim
+++ b/src/helpers/xml.nim
@@ -13,7 +13,7 @@
 
 when defined(PARSERS):
     import strtabs
-    import tables, xmlparser, xmltree
+    import tables, parsexml, xmlparser, xmltree
 
     import extras/htmlparser
 
@@ -83,7 +83,7 @@ when defined(PARSERS):
                 result.d["value"] = newString(node.text)
 
     proc parseXMLInput*(input: string): Value =
-        let root = parseXml(input)
+        let root = parseXml(input, options = {reportComments, reportWhitespace})
         result = newDictionary()
         result.d["kind"] = newLiteral("document")
         var children = newBlock()

--- a/src/library/Strings.nim
+++ b/src/library/Strings.nim
@@ -207,6 +207,31 @@ proc defineModule*(moduleName: string) =
                 else:
                     push(newString(strutils.escape(x.s)))
 
+    when defined(PARSERS):
+        builtin "unescape",
+            alias       = unaliased,
+            op          = opNop,
+            rule        = PrefixPrecedence,
+            description = "decode HTML/XML entities in given string",
+            args        = {
+                "string": {String,Literal,PathLiteral}
+            },
+            attrs       = {
+                "xml"   : ({Logical},"decode XML entities (same rules as HTML)"),
+                "html"  : ({Logical},"decode HTML entities (default)")
+            },
+            returns     = {String,Nothing},
+            example     = """
+                print unescape "a &amp; b &lt; c &#65;"
+                ; a & b < c A
+            """:
+                #=======================================================
+                if xKind in {Literal, PathLiteral}:
+                    ensureInPlaceAny()
+                    SetInPlaceAny(newString(unescapeHtmlEntities(InPlaced.s)))
+                else:
+                    push(newString(unescapeHtmlEntities(x.s)))
+
     builtin "indent",
         alias       = unaliased, 
         op          = opNop,

--- a/src/library/Strings.nim
+++ b/src/library/Strings.nim
@@ -236,7 +236,12 @@ proc defineModule*(moduleName: string) =
             proc doUnescape(s: string): string =
                 if (hadAttr("json")):
                     result = parseJson("\"" & s & "\"").getStr()
-                elif (hadAttr("xml")) or (hadAttr("html")):
+                elif (hadAttr("xml")):
+                    when defined(PARSERS):
+                        result = unescapeXmlEntities(s)
+                    else:
+                        result = s
+                elif (hadAttr("html")):
                     when defined(PARSERS):
                         result = unescapeHtmlEntities(s)
                     else:

--- a/src/library/Strings.nim
+++ b/src/library/Strings.nim
@@ -32,6 +32,7 @@ import helpers/strings
 
 when defined(PARSERS):
     import helpers/html as htmlHelper
+    import helpers/xml as xmlHelper
 
 import vm/lib
 

--- a/src/library/Strings.nim
+++ b/src/library/Strings.nim
@@ -207,30 +207,48 @@ proc defineModule*(moduleName: string) =
                 else:
                     push(newString(strutils.escape(x.s)))
 
-    when defined(PARSERS):
-        builtin "unescape",
-            alias       = unaliased,
-            op          = opNop,
-            rule        = PrefixPrecedence,
-            description = "decode HTML/XML entities in given string",
-            args        = {
-                "string": {String,Literal,PathLiteral}
-            },
-            attrs       = {
-                "xml"   : ({Logical},"decode XML entities (same rules as HTML)"),
-                "html"  : ({Logical},"decode HTML entities (default)")
-            },
-            returns     = {String,Nothing},
-            example     = """
-                print unescape "a &amp; b &lt; c &#65;"
-                ; a & b < c A
-            """:
-                #=======================================================
-                if xKind in {Literal, PathLiteral}:
-                    ensureInPlaceAny()
-                    SetInPlaceAny(newString(unescapeHtmlEntities(InPlaced.s)))
+    builtin "unescape",
+        alias       = unaliased,
+        op          = opNop,
+        rule        = PrefixPrecedence,
+        description = "unescape given string",
+        args        = {
+            "string": {String,Literal,PathLiteral}
+        },
+        attrs       = {
+            "json"  : ({Logical},"from a JSON-escaped string"),
+            "xml"   : ({Logical},"from an XML document"),
+            "html"  : ({Logical},"from an HTML document")
+        },
+        returns     = {String,Nothing},
+        example     = """
+            print unescape "a\\nb\\tc"
+            ; a
+            ; b   c
+            ..........
+            print unescape.json {a \"b\" c}
+            ; a "b" c
+            ..........
+            print unescape.html "a &amp; b &lt; c &#65;"
+            ; a & b < c A
+        """:
+            #=======================================================
+            proc doUnescape(s: string): string =
+                if (hadAttr("json")):
+                    result = parseJson("\"" & s & "\"").getStr()
+                elif (hadAttr("xml")) or (hadAttr("html")):
+                    when defined(PARSERS):
+                        result = unescapeHtmlEntities(s)
+                    else:
+                        result = s
                 else:
-                    push(newString(unescapeHtmlEntities(x.s)))
+                    result = strutils.unescape(s, prefix="", suffix="")
+
+            if xKind in {Literal, PathLiteral}:
+                ensureInPlaceAny()
+                SetInPlaceAny(newString(doUnescape(InPlaced.s)))
+            else:
+                push(newString(doUnescape(x.s)))
 
     builtin "indent",
         alias       = unaliased, 

--- a/src/library/Strings.nim
+++ b/src/library/Strings.nim
@@ -212,54 +212,6 @@ proc defineModule*(moduleName: string) =
                 else:
                     push(newString(strutils.escape(x.s)))
 
-    builtin "unescape",
-        alias       = unaliased,
-        op          = opNop,
-        rule        = PrefixPrecedence,
-        description = "unescape given string",
-        args        = {
-            "string": {String,Literal,PathLiteral}
-        },
-        attrs       = {
-            "json"  : ({Logical},"from a JSON-escaped string"),
-            "xml"   : ({Logical},"from an XML document"),
-            "html"  : ({Logical},"from an HTML document")
-        },
-        returns     = {String,Nothing},
-        example     = """
-            print unescape "a\\nb\\tc"
-            ; a
-            ; b   c
-            ..........
-            print unescape.json {a \"b\" c}
-            ; a "b" c
-            ..........
-            print unescape.html "a &amp; b &lt; c &#65;"
-            ; a & b < c A
-        """:
-            #=======================================================
-            proc doUnescape(s: string): string =
-                if (hadAttr("json")):
-                    result = parseJson("\"" & s & "\"").getStr()
-                elif (hadAttr("xml")):
-                    when defined(PARSERS):
-                        result = unescapeXmlEntities(s)
-                    else:
-                        result = s
-                elif (hadAttr("html")):
-                    when defined(PARSERS):
-                        result = unescapeHtmlEntities(s)
-                    else:
-                        result = s
-                else:
-                    result = strutils.unescape(s, prefix="", suffix="")
-
-            if xKind in {Literal, PathLiteral}:
-                ensureInPlaceAny()
-                SetInPlaceAny(newString(doUnescape(InPlaced.s)))
-            else:
-                push(newString(doUnescape(x.s)))
-
     builtin "indent",
         alias       = unaliased, 
         op          = opNop,
@@ -965,6 +917,54 @@ proc defineModule*(moduleName: string) =
                 else: 
                     ensureInPlaceAny()
                     InPlaced.s = truncate(InPlaced.s, y.i, with)
+
+    builtin "unescape",
+        alias       = unaliased,
+        op          = opNop,
+        rule        = PrefixPrecedence,
+        description = "unescape given string",
+        args        = {
+            "string": {String,Literal,PathLiteral}
+        },
+        attrs       = {
+            "json"  : ({Logical},"from a JSON-escaped string"),
+            "xml"   : ({Logical},"from an XML document"),
+            "html"  : ({Logical},"from an HTML document")
+        },
+        returns     = {String,Nothing},
+        example     = """
+            print unescape "a\\nb\\tc"
+            ; a
+            ; b   c
+            ..........
+            print unescape.json {a \"b\" c}
+            ; a "b" c
+            ..........
+            print unescape.html "a &amp; b &lt; c &#65;"
+            ; a & b < c A
+        """:
+            #=======================================================
+            proc doUnescape(s: string): string =
+                if (hadAttr("json")):
+                    result = parseJson("\"" & s & "\"").getStr()
+                elif (hadAttr("xml")):
+                    when defined(PARSERS):
+                        result = unescapeXmlEntities(s)
+                    else:
+                        result = s
+                elif (hadAttr("html")):
+                    when defined(PARSERS):
+                        result = unescapeHtmlEntities(s)
+                    else:
+                        result = s
+                else:
+                    result = strutils.unescape(s, prefix="", suffix="")
+
+            if xKind in {Literal, PathLiteral}:
+                ensureInPlaceAny()
+                SetInPlaceAny(newString(doUnescape(InPlaced.s)))
+            else:
+                push(newString(doUnescape(x.s)))
 
     builtin "upper",
         alias       = unaliased, 

--- a/src/library/Strings.nim
+++ b/src/library/Strings.nim
@@ -190,8 +190,10 @@ proc defineModule*(moduleName: string) =
                 elif (hadAttr("shell")):
                     when not defined(WEB):
                         SetInPlaceAny(newString(quoteShell(InPlaced.s)))
-                elif (hadAttr("xml")) or (hadAttr("html")):
+                elif (hadAttr("xml")):
                     SetInPlaceAny(newString(xmltree.escape(InPlaced.s)))
+                elif (hadAttr("html")):
+                    SetInPlaceAny(newString(xmltree.escape(InPlaced.s).replace("&apos;", "&#39;")))
                 else:
                     SetInPlaceAny(newString(strutils.escape(InPlaced.s)))
             else:
@@ -202,8 +204,10 @@ proc defineModule*(moduleName: string) =
                 elif (hadAttr("shell")):
                     when not defined(WEB):
                         push(newString(quoteShell(x.s)))
-                elif (hadAttr("xml")) or (hadAttr("html")):
+                elif (hadAttr("xml")):
                     push(newString(xmltree.escape(x.s)))
+                elif (hadAttr("html")):
+                    push(newString(xmltree.escape(x.s).replace("&apos;", "&#39;")))
                 else:
                     push(newString(strutils.escape(x.s)))
 

--- a/src/library/Strings.nim
+++ b/src/library/Strings.nim
@@ -30,6 +30,9 @@ import unicode, std/wordwrap, xmltree
 import helpers/charsets
 import helpers/strings
 
+when defined(PARSERS):
+    import helpers/html as htmlHelper
+
 import vm/lib
 
 when not defined(WEB):
@@ -155,7 +158,8 @@ proc defineModule*(moduleName: string) =
             "json"  : ({Logical},"for literal use in JSON strings"),
             "regex" : ({Logical},"for literal use in regular expression"),
             "shell" : ({Logical},"for use in a shell command"),
-            "xml"   : ({Logical},"for use in an XML document")
+            "xml"   : ({Logical},"for use in an XML document"),
+            "html"  : ({Logical},"for use in an HTML document")
         },
         returns     = {String,Nothing},
         example     = """
@@ -186,7 +190,7 @@ proc defineModule*(moduleName: string) =
                 elif (hadAttr("shell")):
                     when not defined(WEB):
                         SetInPlaceAny(newString(quoteShell(InPlaced.s)))
-                elif (hadAttr("xml")):
+                elif (hadAttr("xml")) or (hadAttr("html")):
                     SetInPlaceAny(newString(xmltree.escape(InPlaced.s)))
                 else:
                     SetInPlaceAny(newString(strutils.escape(InPlaced.s)))
@@ -198,7 +202,7 @@ proc defineModule*(moduleName: string) =
                 elif (hadAttr("shell")):
                     when not defined(WEB):
                         push(newString(quoteShell(x.s)))
-                elif (hadAttr("xml")):
+                elif (hadAttr("xml")) or (hadAttr("html")):
                     push(newString(xmltree.escape(x.s)))
                 else:
                     push(newString(strutils.escape(x.s)))

--- a/tests/unittests/lib.files.art
+++ b/tests/unittests/lib.files.art
@@ -449,6 +449,73 @@ topic "read.html" do
         read.html htmlSample
         read.html ~"|dir|/test.html"
 
+    ; ---------//---------//---------//
+    ; lossless tree shape checks
+    ; ---------//---------//---------//
+
+    parsed: read.html htmlSample
+
+    ; helper to find first child element of `parent` with a given tag
+    findTag: function [parent t][
+        elems: select parent\children 'c -> c\kind = 'element
+        first select elems 'c -> c\tag = t
+    ]
+
+    ; top-level document node
+    ensure -> parsed\kind = 'document
+    ensure -> block? parsed\children
+
+    ; doctype preserved as the first non-whitespace child
+    doctypes: select parsed\children 'c -> c\kind = 'doctype
+    ensure -> 1 = size doctypes
+
+    ; drill into html -> body
+    htmlNode: findTag parsed "html"
+    ensure -> not? null? htmlNode
+    bodyNode: findTag htmlNode "body"
+    ensure -> not? null? bodyNode
+
+    ; helper to extract the text value of the first text-node child
+    firstText: function [node][
+        textKid: first node\children
+        textKid\value
+    ]
+
+    ; <h2> attrs + text content
+    h2: findTag bodyNode "h2"
+    ensure -> "Unordered List with Square Bullets" = firstText h2
+
+    ; <ul> attrs + three <li> element children
+    ul: findTag bodyNode "ul"
+    ensure -> "list-style-type:square;" = ul\attrs\style
+    liElems: select ul\children 'c -> c\kind = 'element
+    ensure -> 3 = size liElems
+    li0: first liElems
+    li1: liElems\1
+    li2: last liElems
+    ensure -> "Arturo" = firstText li0
+    ensure -> "Python" = firstText li1
+    ensure -> "Ruby"   = firstText li2
+
+    ; <p> preserves mixed content (text + <br> + text)
+    p: findTag bodyNode "p"
+    pKinds: map p\children 'c -> c\kind
+    ensure -> contains? pKinds 'text
+    ensure -> contains? pKinds 'element
+    ensure -> not? null? findTag p "br"
+
+    ; ---------//---------//---------//
+    ; comment node preserved
+    ; ---------//---------//---------//
+
+    withComment: read.html {<html><body><!-- hello --><p>x</p></body></html>}
+    html2: findTag withComment "html"
+    body2: findTag html2 "body"
+    commentNodes: select body2\children 'c -> c\kind = 'comment
+    ensure -> 1 = size commentNodes
+    cmt: first commentNodes
+    ensure -> " hello " = cmt\value
+
 ]
 
 topic "read.xml" do

--- a/tests/unittests/lib.files.res
+++ b/tests/unittests/lib.files.res
@@ -148,83 +148,174 @@ This is a multiline File.
 >> read.html
 
 [ :dictionary
-    attrs : [ :dictionary
-    ]
-    text  : 
-
-    Unordered List with Square Bullets
-    
-        Arturo
-        Python
-        Ruby
-    
-    
-        Hello
-        
-        World
-    
-
+    kind     : document :literal
+    children : [ :block
+        [ :dictionary
+            kind  : doctype :literal
+            value : DOCTYPE html :string
+        ]
+        [ :dictionary
+            kind  : text :literal
+            value : 
  :string
-    body  : [ :dictionary
-        attrs : [ :dictionary
         ]
-        text  : 
-    Unordered List with Square Bullets
-    
-        Arturo
-        Python
-        Ruby
-    
-    
-        Hello
-        
-        World
-    
+        [ :dictionary
+            kind     : element :literal
+            tag      : html :string
+            attrs    : [ :dictionary
+            ]
+            children : [ :block
+                [ :dictionary
+                    kind  : text :literal
+                    value : 
  :string
-        h2    : [ :dictionary
-            attrs : [ :dictionary
-            ]
-            text  : Unordered List with Square Bullets :string
-        ]
-        ul    : [ :dictionary
-            attrs : [ :dictionary
-                style : list-style-type:square; :string
-            ]
-            text  : 
-        Arturo
-        Python
-        Ruby
+                ]
+                [ :dictionary
+                    kind     : element :literal
+                    tag      : body :string
+                    attrs    : [ :dictionary
+                    ]
+                    children : [ :block
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
      :string
-            li    : [ :block
-                [ :dictionary
-                    attrs : [ :dictionary
-                    ]
-                    text  : Arturo :string
-                ]
-                [ :dictionary
-                    attrs : [ :dictionary
-                    ]
-                    text  : Python :string
-                ]
-                [ :dictionary
-                    attrs : [ :dictionary
-                    ]
-                    text  : Ruby :string
-                ]
-            ]
-        ]
-        p     : [ :dictionary
-            attrs : [ :dictionary
-            ]
-            text  : 
-        Hello
-        
-        World
+                        ]
+                        [ :dictionary
+                            kind     : element :literal
+                            tag      : h2 :string
+                            attrs    : [ :dictionary
+                            ]
+                            children : [ :block
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : Unordered List with Square Bullets :string
+                                ]
+                            ]
+                        ]
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
      :string
-            br    : [ :dictionary
-                attrs : [ :dictionary
+                        ]
+                        [ :dictionary
+                            kind     : element :literal
+                            tag      : ul :string
+                            attrs    : [ :dictionary
+                                style : list-style-type:square; :string
+                            ]
+                            children : [ :block
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : 
+         :string
+                                ]
+                                [ :dictionary
+                                    kind     : element :literal
+                                    tag      : li :string
+                                    attrs    : [ :dictionary
+                                    ]
+                                    children : [ :block
+                                        [ :dictionary
+                                            kind  : text :literal
+                                            value : Arturo :string
+                                        ]
+                                    ]
+                                ]
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : 
+         :string
+                                ]
+                                [ :dictionary
+                                    kind     : element :literal
+                                    tag      : li :string
+                                    attrs    : [ :dictionary
+                                    ]
+                                    children : [ :block
+                                        [ :dictionary
+                                            kind  : text :literal
+                                            value : Python :string
+                                        ]
+                                    ]
+                                ]
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : 
+         :string
+                                ]
+                                [ :dictionary
+                                    kind     : element :literal
+                                    tag      : li :string
+                                    attrs    : [ :dictionary
+                                    ]
+                                    children : [ :block
+                                        [ :dictionary
+                                            kind  : text :literal
+                                            value : Ruby :string
+                                        ]
+                                    ]
+                                ]
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : 
+     :string
+                                ]
+                            ]
+                        ]
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+     :string
+                        ]
+                        [ :dictionary
+                            kind     : element :literal
+                            tag      : p :string
+                            attrs    : [ :dictionary
+                            ]
+                            children : [ :block
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : 
+         :string
+                                ]
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : Hello
+         :string
+                                ]
+                                [ :dictionary
+                                    kind     : element :literal
+                                    tag      : br :string
+                                    attrs    : [ :dictionary
+                                    ]
+                                    children : [ :block
+                                    ]
+                                ]
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : 
+         :string
+                                ]
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : World
+     :string
+                                ]
+                            ]
+                        ]
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+ :string
+                        ]
+                    ]
                 ]
-                text  :  :string
+                [ :dictionary
+                    kind  : text :literal
+                    value : 
+ :string
+                ]
             ]
         ]
     ]
@@ -232,27 +323,232 @@ This is a multiline File.
 
 >> read.xml
 
-[ :block
-    [ :dictionary
-        name     : Arturo Programming Language :string
-        author   : Yanis Zafiropulos :string
-        category : Scripting and Concatenative :string
-        _tag     : language :string
-        id       : art :string
-    ]
-    [ :dictionary
-        name     : CPython :string
-        author   : Guido van Rossum :string
-        category : Scripting and Object Oriented :string
-        _tag     : language :string
-        id       : py :string
-    ]
-    [ :dictionary
-        name     : Ruby :string
-        author   : Yukihiro Matsumoto :string
-        category : Scripting and Object Oriented :string
-        _tag     : language :string
-        id       : rb :string
+[ :dictionary
+    kind     : document :literal
+    children : [ :block
+        [ :dictionary
+            kind     : element :literal
+            tag      : languages :string
+            attrs    : [ :dictionary
+            ]
+            children : [ :block
+                [ :dictionary
+                    kind  : text :literal
+                    value : 
+ :string
+                ]
+                [ :dictionary
+                    kind     : element :literal
+                    tag      : language :string
+                    attrs    : [ :dictionary
+                        id : art :string
+                    ]
+                    children : [ :block
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+     :string
+                        ]
+                        [ :dictionary
+                            kind     : element :literal
+                            tag      : name :string
+                            attrs    : [ :dictionary
+                            ]
+                            children : [ :block
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : Arturo Programming Language :string
+                                ]
+                            ]
+                        ]
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+     :string
+                        ]
+                        [ :dictionary
+                            kind     : element :literal
+                            tag      : author :string
+                            attrs    : [ :dictionary
+                            ]
+                            children : [ :block
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : Yanis Zafiropulos :string
+                                ]
+                            ]
+                        ]
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+     :string
+                        ]
+                        [ :dictionary
+                            kind     : element :literal
+                            tag      : category :string
+                            attrs    : [ :dictionary
+                            ]
+                            children : [ :block
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : Scripting and Concatenative :string
+                                ]
+                            ]
+                        ]
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+ :string
+                        ]
+                    ]
+                ]
+                [ :dictionary
+                    kind  : text :literal
+                    value : 
+ :string
+                ]
+                [ :dictionary
+                    kind     : element :literal
+                    tag      : language :string
+                    attrs    : [ :dictionary
+                        id : py :string
+                    ]
+                    children : [ :block
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+     :string
+                        ]
+                        [ :dictionary
+                            kind     : element :literal
+                            tag      : name :string
+                            attrs    : [ :dictionary
+                            ]
+                            children : [ :block
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : CPython :string
+                                ]
+                            ]
+                        ]
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+     :string
+                        ]
+                        [ :dictionary
+                            kind     : element :literal
+                            tag      : author :string
+                            attrs    : [ :dictionary
+                            ]
+                            children : [ :block
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : Guido van Rossum :string
+                                ]
+                            ]
+                        ]
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+     :string
+                        ]
+                        [ :dictionary
+                            kind     : element :literal
+                            tag      : category :string
+                            attrs    : [ :dictionary
+                            ]
+                            children : [ :block
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : Scripting and Object Oriented :string
+                                ]
+                            ]
+                        ]
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+ :string
+                        ]
+                    ]
+                ]
+                [ :dictionary
+                    kind  : text :literal
+                    value : 
+ :string
+                ]
+                [ :dictionary
+                    kind     : element :literal
+                    tag      : language :string
+                    attrs    : [ :dictionary
+                        id : rb :string
+                    ]
+                    children : [ :block
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+     :string
+                        ]
+                        [ :dictionary
+                            kind     : element :literal
+                            tag      : name :string
+                            attrs    : [ :dictionary
+                            ]
+                            children : [ :block
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : Ruby :string
+                                ]
+                            ]
+                        ]
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+     :string
+                        ]
+                        [ :dictionary
+                            kind     : element :literal
+                            tag      : author :string
+                            attrs    : [ :dictionary
+                            ]
+                            children : [ :block
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : Yukihiro Matsumoto :string
+                                ]
+                            ]
+                        ]
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+     :string
+                        ]
+                        [ :dictionary
+                            kind     : element :literal
+                            tag      : category :string
+                            attrs    : [ :dictionary
+                            ]
+                            children : [ :block
+                                [ :dictionary
+                                    kind  : text :literal
+                                    value : Scripting and Object Oriented :string
+                                ]
+                            ]
+                        ]
+                        [ :dictionary
+                            kind  : text :literal
+                            value : 
+ :string
+                        ]
+                    ]
+                ]
+                [ :dictionary
+                    kind  : text :literal
+                    value : 
+ :string
+                ]
+            ]
+        ]
     ]
 ]
 


### PR DESCRIPTION
# Description

Up until now, `read.html` returns the content of an HTML document in a flattened dictionary format.
What we'll attempt here is something similar, only in the form of a full (to be read as: lossless) tree, which can be used for further work (e.g. something Nokogiri-style as a package, written in Arturo itself) and far more advanced HTML/XML-related capabilities in general.

Fixes #597 
Fixes #611 

## Type of change

- [x] Code cleanup
- [x] Unit tests (added or updated unit-tests)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (implementation update, or general performance enhancements)
- [x] New feature (non-breaking change which adds functionality)
